### PR TITLE
[react-native-webrtc] Add step to disable bitcode for release iOS builds

### DIFF
--- a/packages/react-native-webrtc/README.md
+++ b/packages/react-native-webrtc/README.md
@@ -8,7 +8,7 @@ Ensure you use versions that work together!
 
 | `expo` | `react-native-webrtc` | `@config-plugins/react-native-webrtc` |
 | ------ | --------------------- | ------------------------------------- |
-| 43.0.0 | 1.92.2                | 0.0.0                                 |
+| 43.0.0 | 1.92.2                | 1.0.0                                 |
 
 > Expo SDK 42 uses `react-native@0.63` which doesn't work with `react-native-webrtc`, specifically iOS production builds fail. Meaning this package is only supported for Expo SDK +43.
 
@@ -58,7 +58,7 @@ export default {
 };
 ```
 
-This plugin will also disable desugaring in the Android `gradle.properties`: `android.enableDexingArtifactTransform.desugaring=false`
+This plugin will also disable desugaring in the Android `gradle.properties`: `android.enableDexingArtifactTransform.desugaring=false`, and disable iOS Bitcode for "Release" builds (required).
 
 ## Manual Setup
 

--- a/packages/react-native-webrtc/build/withBitcodeDisabled.d.ts
+++ b/packages/react-native-webrtc/build/withBitcodeDisabled.d.ts
@@ -1,0 +1,2 @@
+import { ConfigPlugin } from "@expo/config-plugins";
+export declare const withBitcodeDisabled: ConfigPlugin;

--- a/packages/react-native-webrtc/build/withBitcodeDisabled.js
+++ b/packages/react-native-webrtc/build/withBitcodeDisabled.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withBitcodeDisabled = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const withBitcodeDisabled = (config) => {
+    return config_plugins_1.withXcodeProject(config, (config) => {
+        // @ts-ignore
+        if (config.ios.bitcode === true || config.ios.bitcode === "Debug") {
+            config_plugins_1.WarningAggregator.addWarningIOS("ios.bitcode", 'react-native-webrtc plugin is overwriting project bitcode settings. WebRTC requires bitcode to be disabled for "Release" builds, targeting physical iOS devices.');
+        }
+        // WebRTC requires Bitcode be disabled for
+        // production iOS builds that target devices, e.g. not simulators.
+        config.modResults.addBuildProperty("ENABLE_BITCODE", "NO", "Release");
+        return config;
+    });
+};
+exports.withBitcodeDisabled = withBitcodeDisabled;

--- a/packages/react-native-webrtc/build/withDesugaring.js
+++ b/packages/react-native-webrtc/build/withDesugaring.js
@@ -6,7 +6,7 @@ const config_plugins_1 = require("@expo/config-plugins");
  * Set the `android.enableDexingArtifactTransform.desugaring` value in the static `gradle.properties` file.
  * This is used to disable desugaring to fix weird Android bugs. [Learn more](https://github.com/jitsi/jitsi-meet/issues/7911#issuecomment-714323255).
  */
-exports.withDesugaring = (config, isDisabled) => {
+const withDesugaring = (config, isDisabled) => {
     const desugaringKey = "android.enableDexingArtifactTransform.desugaring";
     return config_plugins_1.withGradleProperties(config, (config) => {
         config.modResults = config.modResults.filter((item) => {
@@ -23,3 +23,4 @@ exports.withDesugaring = (config, isDisabled) => {
         return config;
     });
 };
+exports.withDesugaring = withDesugaring;

--- a/packages/react-native-webrtc/build/withPermissions.js
+++ b/packages/react-native-webrtc/build/withPermissions.js
@@ -4,7 +4,7 @@ exports.withPermissions = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const CAMERA_USAGE = "Allow $(PRODUCT_NAME) to access your camera";
 const MICROPHONE_USAGE = "Allow $(PRODUCT_NAME) to access your microphone";
-exports.withPermissions = (config, props) => {
+const withPermissions = (config, props) => {
     return config_plugins_1.withInfoPlist(config, (config) => {
         const { cameraPermission, microphonePermission } = props || {};
         config.modResults.NSCameraUsageDescription =
@@ -18,3 +18,4 @@ exports.withPermissions = (config, props) => {
         return config;
     });
 };
+exports.withPermissions = withPermissions;

--- a/packages/react-native-webrtc/build/withWebRTC.js
+++ b/packages/react-native-webrtc/build/withWebRTC.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
+const withBitcodeDisabled_1 = require("./withBitcodeDisabled");
 const withDesugaring_1 = require("./withDesugaring");
 const withPermissions_1 = require("./withPermissions");
 const pkg = { name: "react-native-webrtc", version: "UNVERSIONED" }; //require("react-native-webrtc/package.json");
@@ -8,6 +9,7 @@ const withWebRTC = (config, props = {}) => {
     const _props = props || {};
     // iOS
     config = withPermissions_1.withPermissions(config, _props);
+    config = withBitcodeDisabled_1.withBitcodeDisabled(config);
     // Android
     config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         "android.permission.ACCESS_NETWORK_STATE",

--- a/packages/react-native-webrtc/package.json
+++ b/packages/react-native-webrtc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@config-plugins/react-native-webrtc",
-  "version": "0.0.0",
-  "description": "Config plugin to auto configure react-native-webrtc on prebuild",
+  "version": "1.0.0",
+  "description": "Config plugin to setup react-native-webrtc on prebuild",
   "main": "build/withWebRTC.js",
   "types": "build/withWebRTC.d.ts",
   "sideEffects": false,

--- a/packages/react-native-webrtc/src/withBitcodeDisabled.ts
+++ b/packages/react-native-webrtc/src/withBitcodeDisabled.ts
@@ -1,0 +1,22 @@
+import {
+  ConfigPlugin,
+  WarningAggregator,
+  withXcodeProject,
+} from "@expo/config-plugins";
+
+export const withBitcodeDisabled: ConfigPlugin = (config) => {
+  return withXcodeProject(config, (config) => {
+    // @ts-ignore
+    if (config.ios.bitcode === true || config.ios.bitcode === "Debug") {
+      WarningAggregator.addWarningIOS(
+        "ios.bitcode",
+        'react-native-webrtc plugin is overwriting project bitcode settings. WebRTC requires bitcode to be disabled for "Release" builds, targeting physical iOS devices.'
+      );
+    }
+    // WebRTC requires Bitcode be disabled for
+    // production iOS builds that target devices, e.g. not simulators.
+    config.modResults.addBuildProperty("ENABLE_BITCODE", "NO", "Release");
+
+    return config;
+  });
+};

--- a/packages/react-native-webrtc/src/withWebRTC.ts
+++ b/packages/react-native-webrtc/src/withWebRTC.ts
@@ -3,6 +3,7 @@ import {
   ConfigPlugin,
   createRunOncePlugin,
 } from "@expo/config-plugins";
+import { withBitcodeDisabled } from "./withBitcodeDisabled";
 
 import { withDesugaring } from "./withDesugaring";
 import { IOSPermissionsProps, withPermissions } from "./withPermissions";
@@ -17,6 +18,7 @@ const withWebRTC: ConfigPlugin<IOSPermissionsProps | void> = (
 
   // iOS
   config = withPermissions(config, _props);
+  config = withBitcodeDisabled(config);
 
   // Android
   config = AndroidConfig.Permissions.withPermissions(config, [


### PR DESCRIPTION
Bump `react-native-webrtc@1.0.0`