### PR TITLE
chore: added start-metro script

### DIFF
--- a/apps/app/.gitignore
+++ b/apps/app/.gitignore
@@ -15,6 +15,7 @@ web-build/
 
 /artifacts
 
+/scripts/start.command
 /ios
 /android
 # @generated expo-cli sync-e7dcf75f4e856f7b6f3239b3f3a7dd614ee755a8

--- a/apps/app/detox.config.js
+++ b/apps/app/detox.config.js
@@ -22,7 +22,7 @@ module.exports = {
     "ios.debug": {
       type: "ios.app",
       binaryPath: `${derivedDataPath}/Build/Products/Debug-${sdk}/${iosName}.app`,
-      build: `./scripts/start-metro.sh && xcodebuild -workspace ios/${iosName}.xcworkspace -scheme ${iosName} -configuration Debug -sdk ${sdk} -derivedDataPath ${derivedDataPath} | npx excpretty ./`,
+      build: `./scripts/start-metro.sh && ./scripts/build-detox-ios.sh ${iosName} Debug`,
     },
     "android.debug": {
       type: "android.apk",

--- a/apps/app/detox.config.js
+++ b/apps/app/detox.config.js
@@ -17,18 +17,18 @@ module.exports = {
     "ios.release": {
       type: "ios.app",
       binaryPath: `${derivedDataPath}/Build/Products/Release-${sdk}/${iosName}.app`,
-      build: `export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/${iosName}.xcworkspace -scheme ${iosName} -configuration Release -sdk ${sdk} -derivedDataPath ${derivedDataPath} | npx excpretty ./`,
+      build: `./scripts/build-detox-ios.sh ${iosName} Release YES`,
     },
     "ios.debug": {
       type: "ios.app",
       binaryPath: `${derivedDataPath}/Build/Products/Debug-${sdk}/${iosName}.app`,
-      build: `xcodebuild -workspace ios/${iosName}.xcworkspace -scheme ${iosName} -configuration Debug -sdk ${sdk} -derivedDataPath ${derivedDataPath} | npx excpretty ./`,
+      build: `./scripts/start-metro.sh && xcodebuild -workspace ios/${iosName}.xcworkspace -scheme ${iosName} -configuration Debug -sdk ${sdk} -derivedDataPath ${derivedDataPath} | npx excpretty ./`,
     },
     "android.debug": {
       type: "android.apk",
       binaryPath: "android/app/build/outputs/apk/debug/app-debug.apk",
       build:
-        "pushd android; ./gradlew app:assembleDebug app:assembleAndroidTest -DtestBuildType=debug; popd",
+        "./scripts/start-metro.sh && pushd android; ./gradlew app:assembleDebug app:assembleAndroidTest -DtestBuildType=debug; popd",
     },
     "android.release": {
       type: "android.apk",

--- a/apps/app/scripts/build-detox-ios.sh
+++ b/apps/app/scripts/build-detox-ios.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This script wraps the xcodebuild command and exits with non-zero if the build fails. 
+#
+# This ensures that CI fails on the correct step instead of attempting to run Detox tests without a
+# build.
+
+set -eu
+
+iosName=$1
+# Debug or Release
+configuration=$2
+# YES or NO
+UseModernBuildSystem=${3:-"NO"}
+
+xcodebuild \
+  -workspace ios/$iosName.xcworkspace \
+  -scheme $iosName \
+  -configuration "$configuration" \
+  -sdk iphonesimulator \
+  -derivedDataPath "ios/build" \
+  -UseModernBuildSystem="$UseModernBuildSystem" 2>&1 | npx excpretty ./
+
+if [ "${PIPESTATUS[0]}" -ne "0" ]; then
+  echo 'Build Failed'
+  set +e
+  exit 1
+fi
+
+echo 'Build Succeeded'

--- a/apps/app/scripts/start-metro.sh
+++ b/apps/app/scripts/start-metro.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+port=${1:-8081}
+
+PACKAGER_STATUS_URL="http://localhost:${port}/status"
+# Check if Metro is running
+STATUS=$(curl --silent $PACKAGER_STATUS_URL)
+
+if [ "${STATUS}" = "packager-status:running" ]; then
+    echo " ✅ Verified Metro Bundler is running."
+else
+    echo " ⚠️  Starting Metro Bundler..."
+    # yarn run clear-metro
+    # yarn start
+
+  commandFile=$(dirname "$0")/start.command
+  cat > ${commandFile} << EOF
+cd "\$(dirname "\$0")/.."
+# Run 'react-native start --help' to get more parameters
+yarn start --port ${port}
+EOF
+  # execute the file in a new command line window
+  chmod 0755 ${commandFile}
+  case "$OSTYPE" in
+     darwin*)
+        open ${commandFile}
+        ;;
+     *)
+        # Spawns a new terminal window and detaches it
+        # Assuming the non-standard variable $TERMINAL is set
+        if [ -z "$TERMINAL" ]; then
+          echo "Could not open a new terminal window. Please make sure to export TERMINAL='your-terminal'"
+        else
+          nohup "$TERMINAL" -e "${commandFile}" </dev/null >/dev/null 2>&1 &
+        fi
+        ;;
+  esac
+
+fi


### PR DESCRIPTION
I don't known why, but iOS release build still crashed on start. Look like it related to expo-updates module.

```
Application Specific Information:
dyld4 config: DYLD_ROOT_PATH=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
CoreSimulator 776.4 - Device: iPhone 13 Pro (152AB63A-3F82-4D26-9AE3-36207700E62C) - Runtime: iOS 15.0 (19A339) - DeviceType: iPhone 13 Pro
terminating with uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'expo-updates is enabled, but no valid URL is configured under EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once.'
dyld4 config: DYLD_ROOT_PATH=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
abort() called
```