### PR TITLE
Fix optional status in withXcodeLinkBinaryWithLibraries

### DIFF
--- a/packages/react-native-callkeep/src/withCallkeep.ts
+++ b/packages/react-native-callkeep/src/withCallkeep.ts
@@ -130,7 +130,7 @@ export const withXcodeLinkBinaryWithLibraries: ConfigPlugin<{
 }> = (config, { library, status }) => {
   return withXcodeProject(config, (config) => {
     const options =
-      status === "optional" ? { settings: { ATTRIBUTES: ["Weak"] } } : {};
+      status === "optional" ? { weak: true } } : {};
 
     const target = IOSConfig.XcodeUtils.getApplicationNativeTarget({
       project: config.modResults,

--- a/packages/react-native-callkeep/src/withCallkeep.ts
+++ b/packages/react-native-callkeep/src/withCallkeep.ts
@@ -130,7 +130,7 @@ export const withXcodeLinkBinaryWithLibraries: ConfigPlugin<{
 }> = (config, { library, status }) => {
   return withXcodeProject(config, (config) => {
     const options =
-      status === "optional" ? { weak: true } } : {};
+      status === "optional" ? { weak: true } : {};
 
     const target = IOSConfig.XcodeUtils.getApplicationNativeTarget({
       project: config.modResults,


### PR DESCRIPTION
The `xcode` module used to update the XCode files is directly setting the `ATTRIBUTES` key for us:

https://github.com/apache/cordova-node-xcode/blob/8b98cabc5978359db88dc9ff2d4c015cba40f150/lib/pbxFile.js#L215-L216

In that case, we simply need to pass `weak: true` instead of the full `settings` object.