### PR TITLE
[ios-stickers] Added JSON schema validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
             # Manually add packages here
             detox,
             ffmpeg-kit-react-native,
+            ios-stickers,
             react-native-ble-plx,
             react-native-blob-util,
             react-native-google-cast,

--- a/packages/ios-stickers/build/options.json
+++ b/packages/ios-stickers/build/options.json
@@ -1,0 +1,58 @@
+{
+    "title": "@config-plugins/ios-stickers options",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/Props",
+    "definitions": {
+        "Props": {
+            "type": "object",
+            "properties": {
+                "stickers": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "$ref": "#/definitions/Sticker"
+                            }
+                        ]
+                    }
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "columns": {
+                    "type": "number",
+                    "enum": [
+                        2,
+                        3,
+                        4
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "Sticker": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "accessibilityLabel": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "image"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/packages/ios-stickers/build/withStickerPack.js
+++ b/packages/ios-stickers/build/withStickerPack.js
@@ -4,6 +4,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normalizeStickersProps = void 0;
+const schema_utils_1 = require("schema-utils");
+const options_json_1 = __importDefault(require("./options.json"));
 const withStickerAssets_1 = require("./withStickerAssets");
 const withStickerInfoPlist_1 = require("./withStickerInfoPlist");
 const withStickerXcodeTarget_1 = require("./withStickerXcodeTarget");
@@ -29,7 +31,10 @@ function normalizeStickersProps(props = []) {
     });
 }
 exports.normalizeStickersProps = normalizeStickersProps;
-const withStickerPack = (config, { stickers, icon, name, columns = 3 } = {}) => {
+const withStickerPack = (config, options = {}) => {
+    // Perform option validation.
+    schema_utils_1.validate(options_json_1.default, options);
+    const { stickers, icon, name, columns = 3 } = options;
     const size = sizeColumnMap[columns] || "regular";
     if (!size) {
         throw new Error(`Column size "${columns}" is invalid. Expected one of: ${Object.keys(sizeColumnMap).join(", ")}`);

--- a/packages/ios-stickers/jest.config.js
+++ b/packages/ios-stickers/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/ios-stickers/package.json
+++ b/packages/ios-stickers/package.json
@@ -23,12 +23,10 @@
     "react",
     "expo"
   ],
-  "jest": {
-    "preset": "expo-module-scripts"
-  },
   "dependencies": {
     "@expo/config-plugins": "^4.0.7",
     "@expo/image-utils": "^0.3.17",
+    "schema-utils": "^4.0.0",
     "xcode": "^3.0.1"
   },
   "devDependencies": {

--- a/packages/ios-stickers/src/__tests__/withStickerPack-test.ts
+++ b/packages/ios-stickers/src/__tests__/withStickerPack-test.ts
@@ -1,0 +1,32 @@
+import withStickerPack from "../withStickerPack";
+
+const exp = { name: "foo", slug: "bar" };
+describe(withStickerPack, () => {
+  it("should not throw when options are valid", () => {
+    expect(() =>
+      withStickerPack(exp, {
+        name: "test",
+        stickers: [{ image: "test.png" }],
+        columns: 2,
+        icon: "test.png",
+      })
+    ).not.toThrow();
+  });
+  it("should not throw when no options are provided", () => {
+    expect(() => withStickerPack(exp, {})).not.toThrow();
+  });
+  it("should throw if columns is not a number", () => {
+    expect(() => {
+      withStickerPack(exp, {
+        stickers: [],
+        icon: "",
+        name: "",
+        columns: "3",
+      } as any);
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Invalid options object. @config-plugins/ios-stickers has been initialized using an options object that does not match the API schema.
+       - options.columns should be one of these:
+         2 | 3 | 4"
+    `);
+  });
+});

--- a/packages/ios-stickers/src/options.json
+++ b/packages/ios-stickers/src/options.json
@@ -1,0 +1,58 @@
+{
+    "title": "@config-plugins/ios-stickers options",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/Props",
+    "definitions": {
+        "Props": {
+            "type": "object",
+            "properties": {
+                "stickers": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "$ref": "#/definitions/Sticker"
+                            }
+                        ]
+                    }
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "columns": {
+                    "type": "number",
+                    "enum": [
+                        2,
+                        3,
+                        4
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "Sticker": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "accessibilityLabel": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "image"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/packages/ios-stickers/src/withStickerPack.ts
+++ b/packages/ios-stickers/src/withStickerPack.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from "@expo/config-plugins";
-
+import { validate } from "schema-utils";
+import schema from "./options.json";
 import { Props, Sticker, withStickerAssets } from "./withStickerAssets";
 import { withStickersPlist } from "./withStickerInfoPlist";
 import { withStickerXcodeTarget } from "./withStickerXcodeTarget";
@@ -30,10 +31,12 @@ export function normalizeStickersProps(
   });
 }
 
-const withStickerPack: ConfigPlugin<Props> = (
-  config,
-  { stickers, icon, name, columns = 3 } = {}
-) => {
+const withStickerPack: ConfigPlugin<Props> = (config, options = {}) => {
+  // Perform option validation.
+  validate(schema as any, options);
+
+  const { stickers, icon, name, columns = 3 } = options;
+
   const size = sizeColumnMap[columns] || "regular";
   if (!size) {
     throw new Error(

--- a/packages/ios-stickers/tsconfig.json
+++ b/packages/ios-stickers/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.plugin",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "resolveJsonModule": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,6 +4159,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -4727,10 +4732,24 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv-keywords@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
@@ -4740,6 +4759,16 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.8.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.9.0.tgz#738019146638824dea25edcf299dcba1b0e7eb18"
+  integrity sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.6.3:
@@ -8310,7 +8339,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -15589,6 +15618,16 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.6"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+schema-utils@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.0.tgz#60331e9e3ae78ec5d16353c467c34b3a0a1d3df7"
+  integrity sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.8.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.0.0"
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"


### PR DESCRIPTION
Experiment with using `schema-utils` from Webpack to validate the TypeScript properties and throw an error during introspection and prebuilding. 

This looks something like:

```
Invalid options object. @config-plugins/ios-stickers has been initialized using an options object that does not match the API schema.
 - options.stickers[0] should be one of these:
   string | object { image, name?, accessibilityLabel? }
   Details:
    * options.stickers[0] should be a string.
    * options.stickers[0] should be an object:
      object { image, name?, accessibilityLabel? }
 - options.columns should be one of these:
   2 | 3 | 4
ValidationError: Invalid options object. @config-plugins/ios-stickers has been initialized using an options object that does not match the API schema.
 - options.stickers[0] should be one of these:
   string | object { image, name?, accessibilityLabel? }
   Details:
    * options.stickers[0] should be a string.
    * options.stickers[0] should be an object:
      object { image, name?, accessibilityLabel? }
 - options.columns should be one of these:
   2 | 3 | 4
    at Object.validate (/Users/evanbacon/Documents/GitHub/config-plugins/packages/ios-stickers/node_modules/schema-utils/dist/validate.js:115:11)
    at withStickerPack (/Users/evanbacon/Documents/GitHub/config-plugins/packages/ios-stickers/build/withStickerPack.js:36:20)
    at withStaticPlugin (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/withStaticPlugin.ts:138:12)
    at /Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/withPlugins.ts:20:43
    at Array.reduce (<anonymous>)
    at withPlugins (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/withPlugins.ts:20:18)
    at withConfigPlugins (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config/src/plugins/withConfigPlugins.ts:19:14)
    at fillAndReturnConfig (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config/src/Config.ts:126:35)
    at getConfig (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config/src/Config.ts:186:12)
    at getPrebuildConfig (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/prebuild-config/src/getPrebuildConfig.ts:47:34)
```
