### PR TITLE
[webrtc] Fully disable bitcode to support development builds on physical devices

### DIFF
--- a/packages/react-native-webrtc/build/withBitcodeDisabled.js
+++ b/packages/react-native-webrtc/build/withBitcodeDisabled.js
@@ -7,14 +7,13 @@ const withBitcodeDisabled = (config) => {
     if (!config.ios) {
         config.ios = {};
     }
-    if (((_a = config.ios) === null || _a === void 0 ? void 0 : _a.bitcode) === false ||
-        (((_b = config.ios) === null || _b === void 0 ? void 0 : _b.bitcode) && config.ios.bitcode !== "Debug")) {
-        config_plugins_1.WarningAggregator.addWarningIOS("ios.bitcode", 'react-native-webrtc plugin is overwriting project bitcode settings. WebRTC requires bitcode to be disabled for "Release" builds, targeting physical iOS devices.');
+    if (((_a = config.ios) === null || _a === void 0 ? void 0 : _a.bitcode) != null && ((_b = config.ios) === null || _b === void 0 ? void 0 : _b.bitcode) !== false) {
+        config_plugins_1.WarningAggregator.addWarningIOS("ios.bitcode", "react-native-webrtc plugin is overwriting project bitcode settings. WebRTC requires bitcode to be disabled for builds, targeting physical iOS devices.");
     }
     // WebRTC requires Bitcode be disabled for
-    // production iOS builds that target devices, e.g. not simulators.
+    // production AND development iOS builds that target devices, e.g. not simulators.
     // SDK +44 property
-    config.ios.bitcode = "Debug";
+    config.ios.bitcode = false;
     return config;
 };
 exports.withBitcodeDisabled = withBitcodeDisabled;

--- a/packages/react-native-webrtc/package.json
+++ b/packages/react-native-webrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-webrtc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Config plugin to setup react-native-webrtc on prebuild",
   "main": "build/withWebRTC.js",
   "types": "build/withWebRTC.d.ts",

--- a/packages/react-native-webrtc/src/withBitcodeDisabled.ts
+++ b/packages/react-native-webrtc/src/withBitcodeDisabled.ts
@@ -5,18 +5,15 @@ export const withBitcodeDisabled: ConfigPlugin = (config) => {
     config.ios = {};
   }
 
-  if (
-    config.ios?.bitcode === false ||
-    (config.ios?.bitcode && config.ios.bitcode !== "Debug")
-  ) {
+  if (config.ios?.bitcode != null && config.ios?.bitcode !== false) {
     WarningAggregator.addWarningIOS(
       "ios.bitcode",
-      'react-native-webrtc plugin is overwriting project bitcode settings. WebRTC requires bitcode to be disabled for "Release" builds, targeting physical iOS devices.'
+      "react-native-webrtc plugin is overwriting project bitcode settings. WebRTC requires bitcode to be disabled for builds, targeting physical iOS devices."
     );
   }
   // WebRTC requires Bitcode be disabled for
-  // production iOS builds that target devices, e.g. not simulators.
+  // production AND development iOS builds that target devices, e.g. not simulators.
   // SDK +44 property
-  config.ios.bitcode = "Debug";
+  config.ios.bitcode = false;
   return config;
 };


### PR DESCRIPTION
I found that while testing a webrtc build on a physical iOS device `expo run:ios -d` the build failed with: 

```
❌  ld: '/Users/evanbacon/Library/Developer/Xcode/DerivedData/withwebrtc-dmominfdhzvvbtawatnmnjajrizk/Build/Products/Debug-iphoneos/XCFrameworkIntermediates/react-native-webrtc/WebRTC.framework/WebRTC' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. file '/Users/evanbacon/Library/Developer/Xcode/DerivedData/withwebrtc-dmominfdhzvvbtawatnmnjajrizk/Build/Products/Debug-iphoneos/XCFrameworkIntermediates/react-native-webrtc/WebRTC.framework/WebRTC' for architecture arm64

❌  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The solution was to fully disable bitcode which is what this PR does.
