### PR TITLE
chore(networkConfig): Fix android crash on empty subdomains config

### DIFF
--- a/packages/detox/README.md
+++ b/packages/detox/README.md
@@ -58,7 +58,7 @@ Detox is an end-to-end (e2e) testing library for iOS and Android. You can use it
 The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
 
 - `skipProguard` (_boolean_): Disable adding proguard minification to the `app/build.gradle`. Defaults to `false`.
-- `subdomains` (_string[] | '*'_): Subdomains to add to the network security config. Pass `'*'` to allow all domans. Defaults to `['10.0.2.2', 'localhost']`.
+- `subdomains` (_string[] | '*'_): Hostnames to add to the network security config. Pass `'*'` to allow all domains. Defaults to `['10.0.2.2', 'localhost']`.
 
 `app.config.js`
 

--- a/packages/detox/README.md
+++ b/packages/detox/README.md
@@ -53,6 +53,29 @@ Detox is an end-to-end (e2e) testing library for iOS and Android. You can use it
 - Generate the native code `expo prebuild`
 - Run `yarn detox init -r jest`
 
+## API
+
+The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
+
+- `skipProguard` (_boolean_): Disable adding proguard minification to the `app/build.gradle`. Defaults to `false`.
+- `subdomains` (_string[] | '*'_): Subdomains to add to the network security config. Pass `'*'` to allow all domans. Defaults to `['10.0.2.2', 'localhost']`.
+
+`app.config.js`
+
+```ts
+export default {
+  plugins: [
+    [
+      "@config-plugins/detox",
+      {
+        skipProguard: false,
+        subdomains: ["10.0.2.2", "localhost"],
+      },
+    ],
+  ],
+};
+```
+
 ## FAQ
 
 If the following commands fail, you can get better debug info by running a subset command:

--- a/packages/detox/build/withDetox.d.ts
+++ b/packages/detox/build/withDetox.d.ts
@@ -1,4 +1,5 @@
 import { ConfigPlugin } from "@expo/config-plugins";
+import { SubdomainsType } from "./withNetworkSecurityConfig";
 declare const _default: ConfigPlugin<void | {
     /**
      * Disable adding proguard minification to the `app/build.gradle`.
@@ -9,9 +10,10 @@ declare const _default: ConfigPlugin<void | {
     /**
      * Subdomains to add to the network security config.
      * Pass `['10.0.3.2', 'localhost']` to use Genymotion emulators instead of Google emulators.
+     * Pass `*` to allow all domains.
      *
      * @default ['10.0.2.2', 'localhost'] // (Google emulators)
      */
-    subdomains?: string[] | undefined;
+    subdomains?: SubdomainsType | undefined;
 }>;
 export default _default;

--- a/packages/detox/build/withNetworkSecurityConfig.d.ts
+++ b/packages/detox/build/withNetworkSecurityConfig.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from "@expo/config-plugins";
-export declare function getTemplateFile(subdomains: string[]): string;
+export declare type SubdomainsType = string[] | "*";
+export declare function getTemplateFile(subdomains: SubdomainsType): string;
 /**
  * [Step 6](https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md#6-enable-clear-text-unencrypted-traffic-for-detox). Link the `network_security_config.xml` file to the `AndroidManifest.xml`.
  */

--- a/packages/detox/build/withNetworkSecurityConfig.d.ts
+++ b/packages/detox/build/withNetworkSecurityConfig.d.ts
@@ -5,5 +5,5 @@ export declare function getTemplateFile(subdomains: SubdomainsType): string;
  * [Step 6](https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md#6-enable-clear-text-unencrypted-traffic-for-detox). Link the `network_security_config.xml` file to the `AndroidManifest.xml`.
  */
 export declare const withNetworkSecurityConfigManifest: ConfigPlugin<{
-    subdomains: string[];
+    subdomains: SubdomainsType;
 } | void>;

--- a/packages/detox/src/__tests__/__snapshots__/withNetworkSecurityConfig-test.ts.snap
+++ b/packages/detox/src/__tests__/__snapshots__/withNetworkSecurityConfig-test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getTemplateFile returns domain-config when subdomains is an array 1`] = `
+"
+    <?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+    <network-security-config>
+      
+    <domain-config cleartextTrafficPermitted=\\"true\\">
+      <domain includeSubdomains=\\"true\\">localhost</domain>
+    </domain-config>
+  
+    </network-security-config>
+  "
+`;
+
+exports[`getTemplateFile returns only base-config when subdomains is '*' 1`] = `
+"
+    <?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+    <network-security-config>
+      <base-config cleartextTrafficPermitted=\\"true\\" />
+    </network-security-config>
+  "
+`;
+
+exports[`withNetworkSecurityConfigManifest doesn't modify config if subdomains is an empty array 1`] = `
+Object {
+  "name": "foo",
+  "slug": "bar",
+}
+`;
+
+exports[`withNetworkSecurityConfigManifest modifies config if subdomains is not empty 1`] = `
+Object {
+  "mods": Object {
+    "android": Object {
+      "dangerous": [Function],
+      "manifest": [Function],
+    },
+  },
+  "name": "foo",
+  "slug": "bar",
+}
+`;

--- a/packages/detox/src/__tests__/withNetworkSecurityConfig-test.ts
+++ b/packages/detox/src/__tests__/withNetworkSecurityConfig-test.ts
@@ -1,0 +1,38 @@
+import {
+  getTemplateFile,
+  withNetworkSecurityConfigManifest,
+} from "../withNetworkSecurityConfig";
+
+describe(getTemplateFile, () => {
+  it(`returns only base-config when subdomains is '*'`, () => {
+    const content = getTemplateFile("*");
+    expect(content).toMatchSnapshot();
+    expect(content).toMatch(/base\-config/);
+    expect(content).not.toMatch(/domain\-config/);
+  });
+  it(`returns domain-config when subdomains is an array`, () => {
+    const content = getTemplateFile(["localhost"]);
+    expect(content).toMatchSnapshot();
+    expect(content).toMatch(/domain\-config/);
+    expect(content).toMatch(/localhost/);
+  });
+});
+
+const exp = { name: "foo", slug: "bar" };
+
+describe(withNetworkSecurityConfigManifest, () => {
+  it(`doesn't modify config if subdomains is an empty array`, () => {
+    const applied = withNetworkSecurityConfigManifest(exp, {
+      subdomains: [],
+    });
+    expect(applied).toMatchSnapshot();
+    expect(applied).toMatchObject(exp);
+  });
+  it(`modifies config if subdomains is not empty`, () => {
+    const applied = withNetworkSecurityConfigManifest(exp, {
+      subdomains: ["10.0.2.2"],
+    });
+    expect(applied).toMatchSnapshot();
+    expect(applied).toHaveProperty("mods.android");
+  });
+});

--- a/packages/detox/src/__tests__/withNetworkSecurityConfig-test.ts
+++ b/packages/detox/src/__tests__/withNetworkSecurityConfig-test.ts
@@ -26,7 +26,7 @@ describe(withNetworkSecurityConfigManifest, () => {
       subdomains: [],
     });
     expect(applied).toMatchSnapshot();
-    expect(applied).toMatchObject(exp);
+    expect(applied).toStrictEqual(exp);
   });
   it(`modifies config if subdomains is not empty`, () => {
     const applied = withNetworkSecurityConfigManifest(exp, {

--- a/packages/detox/src/withDetox.ts
+++ b/packages/detox/src/withDetox.ts
@@ -8,7 +8,7 @@ import withDetoxProjectGradle from "./withDetoxProjectGradle";
 import withDetoxTestAppGradle from "./withDetoxTestAppGradle";
 import { withDetoxTestClass } from "./withDetoxTestClass";
 import withKotlinGradle from "./withKotlinGradle";
-import { withNetworkSecurityConfigManifest } from "./withNetworkSecurityConfig";
+import { withNetworkSecurityConfigManifest, SubdomainsType } from "./withNetworkSecurityConfig";
 import withProguardGradle from "./withProguardGradle";
 
 const withDetox: ConfigPlugin<{
@@ -21,10 +21,11 @@ const withDetox: ConfigPlugin<{
   /**
    * Subdomains to add to the network security config.
    * Pass `['10.0.3.2', 'localhost']` to use Genymotion emulators instead of Google emulators.
+   * Pass `*` to allow all domains.
    *
    * @default ['10.0.2.2', 'localhost'] // (Google emulators)
    */
-  subdomains?: string[];
+  subdomains?: SubdomainsType;
 } | void> = (config, { skipProguard, subdomains } = {}) => {
   return withPlugins(
     config,

--- a/packages/detox/src/withNetworkSecurityConfig.ts
+++ b/packages/detox/src/withNetworkSecurityConfig.ts
@@ -68,7 +68,7 @@ const withNetworkSecurityConfigFile: ConfigPlugin<{
  */
 export const withNetworkSecurityConfigManifest: ConfigPlugin<
   {
-    subdomains: string[];
+    subdomains: SubdomainsType;
   } | void
 > = (config, props) => {
   if (!props || !props.subdomains) {

--- a/packages/detox/src/withNetworkSecurityConfig.ts
+++ b/packages/detox/src/withNetworkSecurityConfig.ts
@@ -11,14 +11,15 @@ import assert from "assert";
 export function getTemplateFile(subdomains: string[]): string {
   return `<?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        ${subdomains
-          .map(
-            (subdomain) =>
-              `<domain includeSubdomains="true">${subdomain}</domain>`
-          )
+    ${subdomains.length ? `
+      <domain-config cleartextTrafficPermitted="true">
+          ${subdomains
+          .map((subdomain) => `<domain includeSubdomains="true">${subdomain}</domain>`)
           .join("")}
-    </domain-config>
+      </domain-config>
+      ` : 
+      '<base-config cleartextTrafficPermitted="true" />'
+    }
 </network-security-config>
 `;
 }


### PR DESCRIPTION
## Background
The app crashes when `detox` plugin is configured with an empty subdomain in cases where it's desired to allow all traffic.

## Cause
```
      [
        "@config-plugins/detox",
        {
          "subdomains": []
        }
      ]
```
The configuration above generates an invalid xml resulting in a  `Caused by: [android.security.net](http://android.security.net/).config.XmlConfigSource$ParserException: No domain elements in domain-config at: Binary XML file line #3` as it generates

```
<?xml version="1.0" encoding="utf-8"?>
<network-security-config>
    
        <domain-config cleartextTrafficPermitted="true">
           
        </domain-config>
        
</network-security-config>
```


## Fix
This PR inserts a `base-config` instead of a `domain-config` when subdomains is empty to allow all traffic.
```
<?xml version="1.0" encoding="utf-8"?>
<network-security-config>
    <base-config cleartextTrafficPermitted="true" />
</network-security-config>

```
