### PR TITLE
fix(detox): use improved xml generation

### DIFF
--- a/packages/detox/build/withNetworkSecurityConfig.js
+++ b/packages/detox/build/withNetworkSecurityConfig.js
@@ -42,12 +42,15 @@ function getTemplateConfigContent(subdomains) {
 }
 function getTemplateFile(subdomains) {
     const content = getTemplateConfigContent(subdomains);
-    return `
-    <?xml version="1.0" encoding="utf-8"?>
-    <network-security-config>
-      ${content}
-    </network-security-config>
-  `;
+    /**
+     * May not have new lines or spaces in the beginning.
+     * Otherwise build fails with:
+     * "AAPT: error: XML or text declaration not at start of entity"
+     */
+    return `<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+${content}
+</network-security-config>`;
 }
 exports.getTemplateFile = getTemplateFile;
 /**

--- a/packages/detox/src/__tests__/__snapshots__/withNetworkSecurityConfig-test.ts.snap
+++ b/packages/detox/src/__tests__/__snapshots__/withNetworkSecurityConfig-test.ts.snap
@@ -1,25 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getTemplateFile returns domain-config when subdomains is an array 1`] = `
-"
-    <?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-    <network-security-config>
-      
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<network-security-config>
+
     <domain-config cleartextTrafficPermitted=\\"true\\">
       <domain includeSubdomains=\\"true\\">localhost</domain>
     </domain-config>
   
-    </network-security-config>
-  "
+</network-security-config>"
 `;
 
 exports[`getTemplateFile returns only base-config when subdomains is '*' 1`] = `
-"
-    <?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-    <network-security-config>
-      <base-config cleartextTrafficPermitted=\\"true\\" />
-    </network-security-config>
-  "
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<network-security-config>
+<base-config cleartextTrafficPermitted=\\"true\\" />
+</network-security-config>"
 `;
 
 exports[`withNetworkSecurityConfigManifest doesn't modify config if subdomains is an empty array 1`] = `

--- a/packages/detox/src/withNetworkSecurityConfig.ts
+++ b/packages/detox/src/withNetworkSecurityConfig.ts
@@ -29,12 +29,15 @@ function getTemplateConfigContent(subdomains: SubdomainsType) {
 
 export function getTemplateFile(subdomains: SubdomainsType): string {
   const content = getTemplateConfigContent(subdomains);
-  return `
-    <?xml version="1.0" encoding="utf-8"?>
-    <network-security-config>
-      ${content}
-    </network-security-config>
-  `;
+  /**
+   * May not have new lines or spaces in the beginning.
+   * Otherwise build fails with: 
+   * "AAPT: error: XML or text declaration not at start of entity"
+   */
+  return `<?xml version="1.0" encoding="utf-8"?>
+      <network-security-config>
+        ${content}
+      </network-security-config>`;
 }
 
 /**

--- a/packages/detox/src/withNetworkSecurityConfig.ts
+++ b/packages/detox/src/withNetworkSecurityConfig.ts
@@ -35,9 +35,9 @@ export function getTemplateFile(subdomains: SubdomainsType): string {
    * "AAPT: error: XML or text declaration not at start of entity"
    */
   return `<?xml version="1.0" encoding="utf-8"?>
-      <network-security-config>
-        ${content}
-      </network-security-config>`;
+<network-security-config>
+${content}
+</network-security-config>`;
 }
 
 /**


### PR DESCRIPTION
This PR changes the xml templating so that it does not have leading spaces or new lines.

This is because leading whitespaces/new lines lead to the error:
"AAPT: error: XML or text declaration not at start of entity"

If neccessary I can create a reproduction repo tomorrow.