### PR TITLE
ci: change release config order

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -49,6 +49,7 @@ module.exports = {
       },
     ],
     "@semantic-release/changelog",
+    "@semantic-release/npm",
     [
       "@semantic-release/git",
       {
@@ -57,6 +58,5 @@ module.exports = {
       },
     ],
     "@semantic-release/github",
-    "@semantic-release/npm",
   ],
 };


### PR DESCRIPTION
The npm package version wasn't being updated before, it appears that this is related to the order in which the plugins were arranged in the release config file. I've moved `npm` to be before `git` and `github`. My working theory is that this will bump the versions then commit rather than committing then bumping versions.