### PR TITLE
ci: fix versions

### DIFF
--- a/packages/android-jsc-intl/package.json
+++ b/packages/android-jsc-intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/android-jsc-intl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Config plugin for android-jsc-intl package",
   "main": "build/withAndroidJscIntl.js",
   "types": "build/withAndroidJscIntl.d.ts",

--- a/packages/detox/CHANGELOG.md
+++ b/packages/detox/CHANGELOG.md
@@ -1,8 +1,1 @@
-### @config-plugins/detox [1.0.1](https://github.com/expo/config-plugins/compare/@config-plugins/detox@1.0.0...@config-plugins/detox@1.0.1) (2022-03-15)
-
-
-### Bug Fixes
-
-* **detox:** remove invalid changelog entries ([4affbbb](https://github.com/expo/config-plugins/commit/4affbbb7ccd0d1309e6711a73bd4227011849064))
-
-## @config-plugins/detox 1.2.0
+### @config-plugins/detox 1.2.0

--- a/packages/ffmpeg-kit-react-native/package.json
+++ b/packages/ffmpeg-kit-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/ffmpeg-kit-react-native",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure FFMPEG on prebuild",
   "main": "build/withFFMPEG.js",
   "types": "build/withFFMPEG.d.ts",

--- a/packages/ios-stickers/package.json
+++ b/packages/ios-stickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/ios-stickers",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure iOS iMessage stickers",
   "main": "build/withStickerPack.js",
   "types": "build/withStickerPack.d.ts",

--- a/packages/react-native-adjust/package.json
+++ b/packages/react-native-adjust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-adjust",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure Adjust SDK on prebuild",
   "main": "build/withReactNativeAdjust.js",
   "types": "build/withReactNativeAdjust.d.ts",

--- a/packages/react-native-ble-plx/package.json
+++ b/packages/react-native-ble-plx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-ble-plx",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure react-native-ble-plx on prebuild",
   "main": "build/withBLE.js",
   "types": "build/withBLE.d.ts",

--- a/packages/react-native-blob-util/package.json
+++ b/packages/react-native-blob-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-blob-util",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Config plugin to auto configure react-native-blob-util on prebuild",
   "main": "build/withReactNativeBlobUtil.js",
   "types": "build/withReactNativeBlobUtil.d.ts",

--- a/packages/react-native-branch/package.json
+++ b/packages/react-native-branch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-branch",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure react-native-branch on prebuild",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/react-native-callkeep/package.json
+++ b/packages/react-native-callkeep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-callkeep",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure callkeep on prebuild",
   "main": "build/withCallkeep.js",
   "types": "build/withCallkeep.d.ts",

--- a/packages/react-native-dynamic-app-icon/package.json
+++ b/packages/react-native-dynamic-app-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-dynamic-app-icon",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure react-native-dynamic-app-icon",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/react-native-google-cast/package.json
+++ b/packages/react-native-google-cast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-google-cast",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure Google Cast on prebuild",
   "main": "build/withGoogleCast.js",
   "types": "build/withGoogleCast.d.ts",

--- a/packages/react-native-pdf/package.json
+++ b/packages/react-native-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-pdf",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Config plugin to auto configure react-native-pdf on prebuild",
   "main": "build/withPdf.js",
   "types": "build/withPdf.d.ts",

--- a/packages/react-native-quick-actions/package.json
+++ b/packages/react-native-quick-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-quick-actions",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Config plugin for react-native-quick-actions package",
   "main": "build/withReactNativeQuickActions.js",
   "types": "build/withReactNativeQuickActions.d.ts",

--- a/packages/react-native-webrtc/CHANGELOG.md
+++ b/packages/react-native-webrtc/CHANGELOG.md
@@ -1,6 +1,1 @@
-## @config-plugins/react-native-webrtc 1.0.0 (2022-03-15)
-
-
-### Other chores
-
-* upgrade @expo/config-plugins ([#49](https://github.com/expo/config-plugins/issues/49)) ([119e31e](https://github.com/expo/config-plugins/commit/119e31edf110409272ace750f02d651124e1a22d))
+## @config-plugins/react-native-webrtc 2.0.1


### PR DESCRIPTION
The versions were committed incorrectly with https://github.com/expo/config-plugins/pull/52 this PR fixes the versions.