### PR TITLE
ci: add statuses permissions to pr title workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    statuses: write
+    permissions:
+      statuses: write
     steps:
       - uses: aslafy-z/conventional-pr-title-action@v2.2.5
         # continue-on-error: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: aslafy-z/conventional-pr-title-action@v2.2.5
         # continue-on-error: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,9 +12,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: read-all
     steps:
       - uses: aslafy-z/conventional-pr-title-action@v2.2.5
         # continue-on-error: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: read-all|write-all
     steps:
       - uses: aslafy-z/conventional-pr-title-action@v2.2.5
         # continue-on-error: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    permissions: read-all|write-all
+    statuses: write
     steps:
       - uses: aslafy-z/conventional-pr-title-action@v2.2.5
         # continue-on-error: true


### PR DESCRIPTION
I updated the title of [this PR](https://github.com/expo/config-plugins/pull/47) but it [failed](https://github.com/expo/config-plugins/runs/5562431256?check_suite_focus=true) with "Error: Resource not accessible by integration".

- Assuming that the [permissions required to make laber action work](https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989) will apply here too, this change should fix the issue. 
- The changes didn't work so I've attempted to use the `statuses` permission directly since that appears to be what the [action is using](https://github.com/aslafy-z/conventional-pr-title-action/blob/61a635ab9df4031dd7876cafe3b4c85dc55f244e/src/index.js#L45).
- [Permissions docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)