### PR TITLE
test: add tests for core plugin methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
             ios-stickers,
             react-native-ble-plx,
             react-native-blob-util,
+            react-native-branch,
             react-native-google-cast,
             react-native-pdf,
             # react-native-quick-actions,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Test ${{ matrix.package }}
-        run: cd packages/${{ matrix.package }} && yarn test
+        run: yarn test
+        working-directory: packages/${{ matrix.package }}
         env:
           CI: true
           EXPO_DEBUG: true

--- a/packages/react-native-branch/src/__tests__/fixtures/react-native-AndroidManifest.xml
+++ b/packages/react-native-branch/src/__tests__/fixtures/react-native-AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <queries>
+        <!-- Support checking for http(s) links via the Linking API -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>

--- a/packages/react-native-branch/src/__tests__/withBranchAndroid-test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchAndroid-test.ts
@@ -1,0 +1,53 @@
+import { AndroidConfig } from "@expo/config-plugins";
+import { resolve } from "path";
+
+import { getBranchApiKey, setBranchApiKey } from "../withBranchAndroid";
+
+const { findMetaDataItem, getMainApplication, readAndroidManifestAsync } =
+  AndroidConfig.Manifest;
+
+const sampleManifestPath = resolve(
+  __dirname,
+  "./fixtures",
+  "react-native-AndroidManifest.xml"
+);
+
+describe(getBranchApiKey, () => {
+  it(`returns null if no android branch api key is provided`, () => {
+    expect(getBranchApiKey({ android: { config: {} } } as any)).toBe(null);
+  });
+
+  it(`returns apikey if android branch api key is provided`, () => {
+    expect(
+      getBranchApiKey({
+        android: { config: { branch: { apiKey: "MY-API-KEY" } } },
+      } as any)
+    ).toBe("MY-API-KEY");
+  });
+});
+
+describe(setBranchApiKey, () => {
+  it("sets branch api key in AndroidManifest.xml if given", async () => {
+    let androidManifestJson = await readAndroidManifestAsync(
+      sampleManifestPath
+    );
+    androidManifestJson = await setBranchApiKey(
+      "MY-API-KEY",
+      androidManifestJson
+    );
+    let mainApplication = getMainApplication(androidManifestJson);
+
+    expect(
+      findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey")
+    ).toBeGreaterThan(-1);
+
+    // Unset the item
+
+    androidManifestJson = await setBranchApiKey(null, androidManifestJson);
+    mainApplication = getMainApplication(androidManifestJson);
+
+    expect(findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey")).toBe(
+      -1
+    );
+  });
+});

--- a/packages/react-native-branch/src/__tests__/withBranchIOS-test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchIOS-test.ts
@@ -1,0 +1,27 @@
+import { getBranchApiKey, setBranchApiKey } from "../withBranchIOS";
+
+describe(getBranchApiKey, () => {
+  it(`returns null if no api key is provided`, () => {
+    expect(getBranchApiKey({})).toBe(null);
+  });
+
+  it(`returns the api key if provided`, () => {
+    expect(
+      getBranchApiKey({ ios: { config: { branch: { apiKey: "123" } } } })
+    ).toBe("123");
+  });
+});
+
+describe(setBranchApiKey, () => {
+  it(`sets branch_key.live if the api key is given`, () => {
+    expect(setBranchApiKey("123", {})).toMatchObject({
+      branch_key: {
+        live: "123",
+      },
+    });
+  });
+
+  it(`makes no changes to the infoPlist no api key is provided`, () => {
+    expect(setBranchApiKey(null, {})).toMatchObject({});
+  });
+});

--- a/packages/react-native-branch/src/withBranchIOS.ts
+++ b/packages/react-native-branch/src/withBranchIOS.ts
@@ -8,7 +8,7 @@ export function getBranchApiKey(config: Pick<ExpoConfig, "ios">) {
 }
 
 export function setBranchApiKey(
-  apiKey: string,
+  apiKey: string | null,
   infoPlist: InfoPlist
 ): InfoPlist {
   if (apiKey === null) {


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

- It's unclear if this works or not https://github.com/expo/config-plugins/pull/63

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Bring over tests from `@expo/prebuild-config`
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- run tests locally
- tests should also show up in CI.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
