### PR TITLE
fix(adjust): upgrade play-services-analytics to v18.0.1

### DIFF
--- a/packages/react-native-adjust/src/withReactNativeAdjust.ts
+++ b/packages/react-native-adjust/src/withReactNativeAdjust.ts
@@ -34,7 +34,7 @@ const addAndroidPackagingOptions = (src: string) => {
     tag: "react-native-play-services-analytics",
     src,
     newSrc: `
-      implementation 'com.google.android.gms:play-services-analytics:18.0.0'
+      implementation 'com.google.android.gms:play-services-analytics:18.0.1'
       implementation 'com.android.installreferrer:installreferrer:2.2'
     `,
     anchor: /dependencies(?:\s+)?\{/,


### PR DESCRIPTION
While publishing my app I have this warning on the Play Store Console:

![Screenshot 2022-03-23 at 14 29 31](https://user-images.githubusercontent.com/5436545/159710654-76df9237-500a-41e0-95d5-b5b3a1b737f5.png)

It seems there is an issue on the `v.18.0.0` SDK, hence I upgraded the dependency to `v.18.0.1`.

Ref: https://developers.google.com/android/guides/releases#december_16_2021

