### PR TITLE
docs: add react-native-multiple-image-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ More out-of-tree plugins which can be used to configure more packages.
 Just install and rebuild! If a package doesn't require any futher setup then it most likely doesn't need an Expo config plugin. Most packages work without a config plugin (including packages not listed below):
 
 - [react-native-share](https://github.com/react-native-share/react-native-share)
-- [`@react-native-menu/menu`](https://github.com/react-native-menu/menu)
+- [@react-native-menu/menu](https://github.com/react-native-menu/menu)
 - [react-native-blurhash](https://github.com/mrousavy/react-native-blurhash)
 - [react-native-app-shortcuts](https://github.com/lokyoung/react-native-app-shortcuts)
+- [react-native-multiple-image-picker](https://github.com/baronha/react-native-multiple-image-picker)
 
 > Feel free to [open a PR](https://github.com/expo/config-plugins/edit/main/README.md) with missing packages.
 


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

Add a reference to another package that doesn't need a config plugin

# How

Update the README to point to the package.

# Test Plan

I created [a new Expo app](https://github.com/wodin/expo-multi-image-picker) based on the example app from [here](https://github.com/baronha/react-native-multiple-image-picker/tree/5c275b21c50848c7139cbdc87cca8cc7e9ee3317/example). I tested it on an Android device and on the iOS Simulator.