### PR TITLE
chore: remove react-native-share from list of packages that do not need a config plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ More out-of-tree plugins which can be used to configure more packages.
 
 Just install and rebuild! If a package doesn't require any futher setup then it most likely doesn't need an Expo config plugin. Most packages work without a config plugin (including packages not listed below):
 
-- [react-native-share](https://github.com/react-native-share/react-native-share)
 - [@react-native-menu/menu](https://github.com/react-native-menu/menu)
 - [react-native-blurhash](https://github.com/mrousavy/react-native-blurhash)
 - [react-native-app-shortcuts](https://github.com/lokyoung/react-native-app-shortcuts)


### PR DESCRIPTION
`react-native-share` now requires (an as yet unwritten) config plugin...

<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
