### PR TITLE
docs: added expo-appcenter to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ More out-of-tree plugins which can be used to configure more packages.
 - [@allboatsrise/expo-marketingcloudsdk](https://www.npmjs.com/package/@allboatsrise/expo-marketingcloudsdk) (for use with `react-native-marketingcloudsdk`)
 - [@ouvio/react-native-background-location-plugin](https://www.npmjs.com/package/@ouvio/react-native-background-location-plugin) (for use with `react-native-background-location-plugin`)
 - [expo-community-flipper](https://www.npmjs.com/package/expo-community-flipper) (for use with Flipper)
+- [expo-appcenter](https://www.npmjs.com/package/expo-appcenter) (for use with `appcenter`)
 
 ### No Plugin Required
 


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

Hi folks! I've made my first plugin for expo, which enables devs to use appcenter within the expo managed workflow!

https://www.npmjs.com/package/expo-appcenter

https://github.com/BelkaLab/expo-appcenter

I saw on [this issue](https://github.com/microsoft/appcenter/issues/189) it was something that community was asking for, so I gave it a try! 


# How

I followed your guide on creating a plugin with typescript and all your conventions. If something is wrong, please give me feedback and I'll fix it :)


# Test Plan

I've created a small app, installed the plugin and appcenter following [their guide](https://docs.microsoft.com/en-us/appcenter/sdk/getting-started/react-native) and checked that the SDK was working.
