### PR TITLE
Fix broken Universal links

### DIFF
--- a/packages/react-native-siri-shortcut/build/withReactNativeSiriShortcut.js
+++ b/packages/react-native-siri-shortcut/build/withReactNativeSiriShortcut.js
@@ -36,12 +36,7 @@ function addSiriShortcutAppDelegateInit(src) {
     return (0, generateCode_1.mergeContents)({
         tag: "react-native-siri-shortcut-delegate",
         src,
-        newSrc: [
-            "  BOOL shortcutResult = [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];",
-            "  if (shortcutResult) {",
-            "    return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || shortcutResult;",
-            "  }",
-        ].join("\n"),
+        newSrc: "  [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];",
         anchor: /  return \[super application:application continueUserActivity:userActivity restorationHandler:restorationHandler\] \|\| result;/,
         offset: -1,
         comment: "//",

--- a/packages/react-native-siri-shortcut/src/__tests__/__snapshots__/withReactNativeSiriShortcut.test.ts.snap
+++ b/packages/react-native-siri-shortcut/src/__tests__/__snapshots__/withReactNativeSiriShortcut.test.ts.snap
@@ -277,11 +277,8 @@ static NSString *const kRNConcurrentRoot = @\\"concurrentRoot\\";
 
 // Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
-// @generated begin react-native-siri-shortcut-delegate - expo prebuild (DO NOT MODIFY) sync-291450a04ff243636b0bd0aef4a614f7218690b5
-  BOOL shortcutResult = [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
-  if (shortcutResult) {
-    return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || shortcutResult;
-  }
+// @generated begin react-native-siri-shortcut-delegate - expo prebuild (DO NOT MODIFY) sync-8b7c8dea13472db94614c8fa0a78dc7330c6c0c0
+  [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
 // @generated end react-native-siri-shortcut-delegate
   BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
   return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;

--- a/packages/react-native-siri-shortcut/src/withReactNativeSiriShortcut.ts
+++ b/packages/react-native-siri-shortcut/src/withReactNativeSiriShortcut.ts
@@ -53,7 +53,8 @@ export function addSiriShortcutAppDelegateInit(src: string): MergeResults {
   return mergeContents({
     tag: "react-native-siri-shortcut-delegate",
     src,
-    newSrc: "  [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];",
+    newSrc:
+      "  [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];",
     anchor:
       /  return \[super application:application continueUserActivity:userActivity restorationHandler:restorationHandler\] \|\| result;/,
     offset: -1,

--- a/packages/react-native-siri-shortcut/src/withReactNativeSiriShortcut.ts
+++ b/packages/react-native-siri-shortcut/src/withReactNativeSiriShortcut.ts
@@ -53,12 +53,7 @@ export function addSiriShortcutAppDelegateInit(src: string): MergeResults {
   return mergeContents({
     tag: "react-native-siri-shortcut-delegate",
     src,
-    newSrc: [
-      "  BOOL shortcutResult = [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];",
-      "  if (shortcutResult) {",
-      "    return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || shortcutResult;",
-      "  }",
-    ].join("\n"),
+    newSrc: "  [RNSSSiriShortcuts application:application continueUserActivity:userActivity restorationHandler:restorationHandler];",
     anchor:
       /  return \[super application:application continueUserActivity:userActivity restorationHandler:restorationHandler\] \|\| result;/,
     offset: -1,


### PR DESCRIPTION
# Why

@config-plugins/react-native-siri-shortcut breaks Universal Links on iOS - this fixes it.

Since [react-native-siri-shortcut always returns true](https://github.com/Gustash/react-native-siri-shortcut/blob/64c892e9d01cfa8d89c47a9287bf978b3213fd46/ios/RNSSSiriShortcuts.m#L85) the standard universal link functionality is never called.

# How

By not returning based on the response from react-native-siri-shortcut.

# Test Plan

By running - and updating - the unit tests. Also - by putting it into production today to fix the broken universal links :)
