### PR TITLE
feat(react-native-keyevent): Config plugin link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ More out-of-tree plugins which can be used to configure more packages.
 - [@ouvio/react-native-background-location-plugin](https://www.npmjs.com/package/@ouvio/react-native-background-location-plugin) (for use with `react-native-background-location-plugin`)
 - [expo-community-flipper](https://www.npmjs.com/package/expo-community-flipper) (for use with Flipper)
 - [expo-appcenter](https://www.npmjs.com/package/expo-appcenter) (for use with `appcenter`)
+- [react-native-keyevent-expo-config-plugin](https://github.com/chronsyn/react-native-keyevent-expo-config-plugin) (for use with `react-native-keyevent`)
 
 ### No Plugin Required
 


### PR DESCRIPTION
# Why

I've recently built an Expo config plugin for [react-native-keyevent](https://github.com/kevinejohn/react-native-keyevent). No public config plugin already exists for this library, so I felt it worth open sourcing and adding a link to the docs that most people are likely to look at.