### PR TITLE
docs(contributing): fix typo in instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To submit a pull request:
 
 1. Fork the [repository](https://github.com/expo/config-plugins) and create a feature branch. (Existing contributors can create feature branches without forking. Prefix the branch name with `@your-github-username/`.)
 2. Run `yarn` in the root directory to generate the build files.
-3. Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) including in the PR tile.
+3. Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) including in the PR title.
 4. Fill out the entire PR template. Ensure your code is tested locally and has continuous tests in CI.
 5. Make sure all tests pass on GitHub Actions.
 6. Wait for a review and adjust the code if necessary.


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
A quick typo fix

# How

<!--
How did you build this feature or fix this bug and why?
-->
n/a 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Just docs updates