### PR TITLE
chore(react-native-ble-plx)!: drop `bluetoothPeripheralPermission` property

### DIFF
--- a/packages/react-native-ble-plx/README.md
+++ b/packages/react-native-ble-plx/README.md
@@ -33,7 +33,8 @@ The plugin provides props for extra customization. Every time you change the pro
 - `neverForLocation` (_boolean_): Set to true only if you can strongly assert that your app never derives physical location from Bluetooth scan results. The location permission will be still required on older Android devices. Note, that some BLE beacons are filtered from the scan results. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
 - `modes` (_string[]_): Adds iOS `UIBackgroundModes` to the `Info.plist`. Options are: `peripheral`, and `central`. Defaults to undefined.
 - `bluetoothAlwaysPermission` (_string | false_): Sets the iOS `NSBluetoothAlwaysUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to connect to bluetooth devices`.
-- `bluetoothPeripheralPermission` (_string | false_): Sets the iOS `NSBluetoothPeripheralUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to connect to bluetooth devices`.
+
+> Expo SDK 47 supports iOS 13+ which means `NSBluetoothPeripheralUsageDescription` is fully deprecated. It is no longer setup in `@config-plugins/react-native-ble-plx@5.0.0` and greater.
 
 #### Example
 
@@ -46,8 +47,7 @@ The plugin provides props for extra customization. Every time you change the pro
         {
           "isBackgroundEnabled": true,
           "modes": ["peripheral", "central"],
-          "bluetoothAlwaysPermission": "Allow $(PRODUCT_NAME) to connect to bluetooth devices",
-          "bluetoothPeripheralPermission": "Allow $(PRODUCT_NAME) to connect to bluetooth devices"
+          "bluetoothAlwaysPermission": "Allow $(PRODUCT_NAME) to connect to bluetooth devices"
         }
       ]
     ]

--- a/packages/react-native-ble-plx/build/withBLE.d.ts
+++ b/packages/react-native-ble-plx/build/withBLE.d.ts
@@ -6,6 +6,5 @@ declare const _default: ConfigPlugin<void | {
     neverForLocation?: boolean | undefined;
     modes?: BackgroundMode[] | undefined;
     bluetoothAlwaysPermission?: string | false | undefined;
-    bluetoothPeripheralPermission?: string | false | undefined;
 }>;
 export default _default;

--- a/packages/react-native-ble-plx/build/withBLE.js
+++ b/packages/react-native-ble-plx/build/withBLE.js
@@ -14,6 +14,9 @@ const withBLE = (config, props = {}) => {
     const _props = props || {};
     const isBackgroundEnabled = _props.isBackgroundEnabled ?? false;
     const neverForLocation = _props.neverForLocation ?? false;
+    if ("bluetoothPeripheralPermission" in _props) {
+        config_plugins_1.WarningAggregator.addWarningIOS("bluetoothPeripheralPermission", `The iOS permission \`NSBluetoothPeripheralUsageDescription\` is fully deprecated as of iOS 13 (lowest iOS version in Expo SDK 47+). Remove the \`bluetoothPeripheralPermission\` property from the \`@config-plugins/react-native-ble-plx\` config plugin.`);
+    }
     // iOS
     config = (0, withBluetoothPermissions_1.withBluetoothPermissions)(config, _props);
     config = (0, withBLEBackgroundModes_1.withBLEBackgroundModes)(config, _props.modes || []);

--- a/packages/react-native-ble-plx/build/withBluetoothPermissions.d.ts
+++ b/packages/react-native-ble-plx/build/withBluetoothPermissions.d.ts
@@ -1,5 +1,4 @@
 import { ConfigPlugin } from "@expo/config-plugins";
 export declare const withBluetoothPermissions: ConfigPlugin<{
     bluetoothAlwaysPermission?: string | false;
-    bluetoothPeripheralPermission?: string | false;
 }>;

--- a/packages/react-native-ble-plx/build/withBluetoothPermissions.js
+++ b/packages/react-native-ble-plx/build/withBluetoothPermissions.js
@@ -3,20 +3,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.withBluetoothPermissions = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const BLUETOOTH_ALWAYS = "Allow $(PRODUCT_NAME) to connect to bluetooth devices";
-const BLUETOOTH_PERIPHERAL_USAGE = "Allow $(PRODUCT_NAME) to connect to bluetooth devices";
-const withBluetoothPermissions = (c, { bluetoothAlwaysPermission, bluetoothPeripheralPermission } = {}) => {
+const withBluetoothPermissions = (c, { bluetoothAlwaysPermission } = {}) => {
     return (0, config_plugins_1.withInfoPlist)(c, (config) => {
         if (bluetoothAlwaysPermission !== false) {
             config.modResults.NSBluetoothAlwaysUsageDescription =
                 bluetoothAlwaysPermission ||
                     config.modResults.NSBluetoothAlwaysUsageDescription ||
                     BLUETOOTH_ALWAYS;
-        }
-        if (bluetoothPeripheralPermission !== false) {
-            config.modResults.NSBluetoothPeripheralUsageDescription =
-                bluetoothPeripheralPermission ||
-                    config.modResults.NSBluetoothPeripheralUsageDescription ||
-                    BLUETOOTH_PERIPHERAL_USAGE;
         }
         return config;
     });

--- a/packages/react-native-ble-plx/src/withBLE.ts
+++ b/packages/react-native-ble-plx/src/withBLE.ts
@@ -2,6 +2,7 @@ import {
   AndroidConfig,
   ConfigPlugin,
   createRunOncePlugin,
+  WarningAggregator,
 } from "@expo/config-plugins";
 
 import { withBLEAndroidManifest } from "./withBLEAndroidManifest";
@@ -22,12 +23,18 @@ const withBLE: ConfigPlugin<
     neverForLocation?: boolean;
     modes?: BackgroundMode[];
     bluetoothAlwaysPermission?: string | false;
-    bluetoothPeripheralPermission?: string | false;
   } | void
 > = (config, props = {}) => {
   const _props = props || {};
   const isBackgroundEnabled = _props.isBackgroundEnabled ?? false;
   const neverForLocation = _props.neverForLocation ?? false;
+
+  if ("bluetoothPeripheralPermission" in _props) {
+    WarningAggregator.addWarningIOS(
+      "bluetoothPeripheralPermission",
+      `The iOS permission \`NSBluetoothPeripheralUsageDescription\` is fully deprecated as of iOS 13 (lowest iOS version in Expo SDK 47+). Remove the \`bluetoothPeripheralPermission\` property from the \`@config-plugins/react-native-ble-plx\` config plugin.`
+    );
+  }
 
   // iOS
   config = withBluetoothPermissions(config, _props);

--- a/packages/react-native-ble-plx/src/withBluetoothPermissions.ts
+++ b/packages/react-native-ble-plx/src/withBluetoothPermissions.ts
@@ -2,25 +2,16 @@ import { ConfigPlugin, withInfoPlist } from "@expo/config-plugins";
 
 const BLUETOOTH_ALWAYS =
   "Allow $(PRODUCT_NAME) to connect to bluetooth devices";
-const BLUETOOTH_PERIPHERAL_USAGE =
-  "Allow $(PRODUCT_NAME) to connect to bluetooth devices";
 
 export const withBluetoothPermissions: ConfigPlugin<{
   bluetoothAlwaysPermission?: string | false;
-  bluetoothPeripheralPermission?: string | false;
-}> = (c, { bluetoothAlwaysPermission, bluetoothPeripheralPermission } = {}) => {
+}> = (c, { bluetoothAlwaysPermission } = {}) => {
   return withInfoPlist(c, (config) => {
     if (bluetoothAlwaysPermission !== false) {
       config.modResults.NSBluetoothAlwaysUsageDescription =
         bluetoothAlwaysPermission ||
         config.modResults.NSBluetoothAlwaysUsageDescription ||
         BLUETOOTH_ALWAYS;
-    }
-    if (bluetoothPeripheralPermission !== false) {
-      config.modResults.NSBluetoothPeripheralUsageDescription =
-        bluetoothPeripheralPermission ||
-        config.modResults.NSBluetoothPeripheralUsageDescription ||
-        BLUETOOTH_PERIPHERAL_USAGE;
     }
     return config;
   });


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

This permission is now fully deprecated as far as Expo is concerned (which has a lower baseline (iOS 13) than apps like Twitter (iOS 14)). We can now safely drop the permission https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothperipheralusagedescription

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
