### PR TITLE
fix(ffmpeg-kit-react-native): fix Android build errors caused by duplicate libc++_shared.so

### DIFF
--- a/packages/ffmpeg-kit-react-native/build/withAndroidFFMPEGPackage.js
+++ b/packages/ffmpeg-kit-react-native/build/withAndroidFFMPEGPackage.js
@@ -4,7 +4,7 @@ exports.addPackageName = exports.withAndroidFFMPEGPackage = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const generateCode_1 = require("@expo/config-plugins/build/utils/generateCode");
 const withAndroidFFMPEGPackage = (config, packageName) => {
-    return (0, config_plugins_1.withProjectBuildGradle)(config, (config) => {
+    config = (0, config_plugins_1.withProjectBuildGradle)(config, (config) => {
         if (config.modResults.language === "groovy") {
             config.modResults.contents = addPackageName(config.modResults.contents, packageName);
         }
@@ -13,6 +13,8 @@ const withAndroidFFMPEGPackage = (config, packageName) => {
         }
         return config;
     });
+    config = withLibCppSharedSo(config);
+    return config;
 };
 exports.withAndroidFFMPEGPackage = withAndroidFFMPEGPackage;
 function addPackageName(src, packageName) {
@@ -51,4 +53,16 @@ function appendContents({ src, newSrc, tag, comment, }) {
         };
     }
     return { contents: src, didClear: false, didMerge: false };
+}
+// This is required if you have several libraries which include libc++_shared.so as a dependency.
+// See https://github.com/tanersener/ffmpeg-kit/wiki/Tips#2-depending-another-android-library-containing-libc_sharedso
+function withLibCppSharedSo(config) {
+    return (0, config_plugins_1.withGradleProperties)(config, (config) => {
+        config.modResults.push({
+            type: "property",
+            key: "android.packagingOptions.pickFirsts",
+            value: "lib/x86/libc++_shared.so,lib/x86_64/libc++_shared.so,lib/armeabi-v7a/libc++_shared.so,lib/arm64-v8a/libc++_shared.so",
+        });
+        return config;
+    });
 }


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes #31.

The root cause of this is the issue described in the [ffmpeg-kit docs](https://github.com/tanersener/ffmpeg-kit/wiki/Tips#2-depending-another-android-library-containing-libc_sharedso):

> If a second library which also includes `libc++_shared.so` is added as a dependency, `gradle` fails with `More than one file was found with OS independent path 'lib/x86/libc++_shared.so'` error message.

This is currently breaking our build, so we're using `patch-package` to apply this diff.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Using https://github.com/expo/expo/pull/15863, which allows us to define a `android.packagingOptions.pickFirsts` property in `gradle.properties`.

Note that this currently doesn't check if there are any other `android.packagingOptions.pickFirsts` properties - I'm not even sure what the behavior should be in general (should it be replaced, appended, ...?).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

So far, this has only been tested by building our app on EAS, using `patch-package` to update the `packages/ffmpeg-kit-react-native/build/withAndroidFFMPEGPackage.js` file.

**Before:** the `gradlew` task fails with the following error:

```
[stderr] Execution failed for task ':app:mergeDebugNativeLibs'.
[stderr] > A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
[stderr]    > 2 files found with path 'lib/arm64-v8a/libc++_shared.so' from inputs:
[stderr] - /home/expo/.gradle/caches/transforms-3/2cc1c6bf49a4b55c6e81278f0aa6c079/transformed/jetified-react-native-0.70.5-debug/jni/arm64-v8a/libc++_shared.so
[stderr]       - /home/expo/.gradle/caches/transforms-3/2a1d5e98bc03f10f84a5b972b15ae4ac/transformed/jetified-ffmpeg-kit-https-gpl-5.1/jni/arm64-v8a/libc++_shared.so
[stderr]      If you are using jniLibs and CMake IMPORTED targets, see
[stderr]      https://developer.android.com/r/tools/jniLibs-vs-imported-targets
[stderr] * Try:
[stderr] > Run with --stacktrace option to get the stack trace.
[stderr] > Run with --info or --debug option to get more log output.
[stderr] > Run with --scan to get full insights.
```

**After:** build succeeds.
