### PR TITLE
remove `fbjs` dependency

### DIFF
--- a/packages/react-native-pdf/README.md
+++ b/packages/react-native-pdf/README.md
@@ -7,7 +7,7 @@ Config plugin to auto-configure [`react-native-pdf`][lib] when the native code i
 > Tested against Expo SDK 48
 
 ```
-yarn add react-native-pdf react-native-blob-util fbjs @config-plugins/react-native-pdf @config-plugins/react-native-blob-util
+yarn add react-native-pdf react-native-blob-util @config-plugins/react-native-pdf @config-plugins/react-native-blob-util
 ```
 
 After installing this npm package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:


### PR DESCRIPTION
Remove `fbjs` because it is not a dependency anymore in `react-native-pdf`

https://github.com/wonday/react-native-pdf/releases/tag/v6.5.0

<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Incorrect docs

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
