### PR TITLE
feat(adjust): add support for sdk signature

### DIFF
--- a/packages/react-native-adjust/README.md
+++ b/packages/react-native-adjust/README.md
@@ -39,4 +39,22 @@ If you are targeting Android 12 and above (API level 31), you need to add it in 
 
 This will add the [appropriate permission](https://github.com/adjust/react_native_sdk#add-permission-to-gather-google-advertising-id) for you.
 
+To set up Adjust [SDK Signature](https://github.com/adjust/react_native_sdk/blob/master/README.md#sdk-signature) you need to specify the path for the xcframework and the aar file.
+```json
+{
+  "expo": {
+    "plugins": [
+      "@config-plugins/react-native-adjust",
+      {
+        "targetAndroid12": true ,
+        "sdkSignature" : {
+          "android" : "./path/to.aar",
+          "ios" : "./path/to.xcframework"
+        }
+      }
+    ]
+  }
+}
+```
+
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why
To implement Adjust [SDK Signature](https://github.com/adjust/react_native_sdk#sdk-signature), the Adjust team generates and provides two custom libraries that need to be integrated in the iOS and Android native projects.

This PR aims to add support for that.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
if the sdk signature library path is specified:

iOS
- copy the sdk signature framework to the ios project folder
- embed and sign the sdk signature framework

Android
- copy the sdk signature aar to android/app/libs
- add required ndk.abiFilters 
- add aar file as a dependency

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tested locally on an existing project

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
![image](https://user-images.githubusercontent.com/19575877/235149263-93bf633f-e27e-4db7-951c-402b21f766ae.png)
![image](https://user-images.githubusercontent.com/19575877/235145675-90ed26e9-26ba-4e91-a058-57e4d606af0d.png)
![image](https://user-images.githubusercontent.com/19575877/235150250-f23f8ea1-7903-472a-bd75-f6108e0f7f7f.png)
![image](https://user-images.githubusercontent.com/19575877/235150071-905d9962-f4de-4746-95b4-bc8e4bbb29c1.png)

