### PR TITLE
fix(react-native-ble-plx) - Adjusted Android permissions

### DIFF
--- a/packages/react-native-ble-plx/README.md
+++ b/packages/react-native-ble-plx/README.md
@@ -34,19 +34,19 @@ The plugin provides props for extra customization. Every time you change the pro
 - `modes` (_string[]_): Adds iOS `UIBackgroundModes` to the `Info.plist`. Options are: `peripheral`, and `central`. Defaults to undefined.
 - `bluetoothAlwaysPermission` (_string | false_): Sets the iOS `NSBluetoothAlwaysUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to connect to bluetooth devices`.
 
+> Expo SDK 48 supports iOS 13+ which means `NSBluetoothPeripheralUsageDescription` is fully deprecated. It is no longer setup in `@config-plugins/react-native-ble-plx@5.0.0` and greater.
+
 ### Android options
 
-- `neverForLocation` (_boolean_): default:`false` - A flag you can set to `true` to assert that your app doesn't use BLE scan results to derive physical location. If `true`, `"android:usesPermissionFlags": "neverForLocation"` will be added to your `"android.permission.BLUETOOTH_SCAN"` declaration. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
-
-- `isRequired` (_boolean_): default:`false` - Determines whether or not your app requires Bluetooth to function. If set to `true`, `<uses-feature android:name="android.hardware.bluetooth" android:required="true"/>` will be added to the `AndroidManifest.xml`.
-
-- `canDiscover` (_boolean_): default:`true` - Indicates whether your app should have the permission to discover other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADMIN` and `android.permission.BLUETOOTH` are added with specific `android:maxSdkVersion` conditionally based on your settings.
-
-- `isDiscoverable` (_boolean_): default:`false` - Dictates whether or not your app is discoverable to other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADVERTISE` will be added to `AndroidManifest.xml`.
+- `canDiscover` (_boolean_): default:`true` - Indicates whether your app should have the permission to discover other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADMIN` and `android:maxSdkVersion` is added conditioanlly based on legacy Android support. conditionally based on your settings.
 
 - `canConnect` (_boolean_): default:`true` - Specifies if your app requires the permission to connect to already-paired Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_CONNECT` will be added to `AndroidManifest.xml`.
 
-> Expo SDK 48 supports iOS 13+ which means `NSBluetoothPeripheralUsageDescription` is fully deprecated. It is no longer setup in `@config-plugins/react-native-ble-plx@5.0.0` and greater.
+- `neverForLocation` (_boolean_): default:`false` - A flag you can set to `true` to assert that your app doesn't use BLE scan results to derive physical location. If `true`, `"android:usesPermissionFlags": "neverForLocation"` will be added to your `"android.permission.BLUETOOTH_SCAN"` declaration. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
+
+- `isDiscoverable` (_boolean_): default:`false` - Dictates whether or not your app is discoverable to other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADVERTISE` will be added to `AndroidManifest.xml`.
+
+- `isRequired` (_boolean_): default:`false` - Determines whether or not your app requires Bluetooth to function. If set to `true`, `<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>` will be added to the `AndroidManifest.xml`.
 
 #### Example
 

--- a/packages/react-native-ble-plx/README.md
+++ b/packages/react-native-ble-plx/README.md
@@ -27,12 +27,24 @@ Next, rebuild your app as described in the ["Adding custom native code"](https:/
 
 ## API
 
+### iOS options
+
 The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
 
-- `isBackgroundEnabled` (_boolean_): Enable background BLE support on Android. Adds `<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>` to the `AndroidManifest.xml`. Default `false`.
-- `neverForLocation` (_boolean_): Set to true only if you can strongly assert that your app never derives physical location from Bluetooth scan results. The location permission will be still required on older Android devices. Note, that some BLE beacons are filtered from the scan results. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
 - `modes` (_string[]_): Adds iOS `UIBackgroundModes` to the `Info.plist`. Options are: `peripheral`, and `central`. Defaults to undefined.
 - `bluetoothAlwaysPermission` (_string | false_): Sets the iOS `NSBluetoothAlwaysUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to connect to bluetooth devices`.
+
+### Android options
+
+- `neverForLocation` (_boolean_): default:`false` - A flag you can set to `true` to assert that your app doesn't use BLE scan results to derive physical location. If `true`, `"android:usesPermissionFlags": "neverForLocation"` will be added to your `"android.permission.BLUETOOTH_SCAN"` declaration. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
+
+- `isRequired` (_boolean_): default:`false` - Determines whether or not your app requires Bluetooth to function. If set to `true`, `<uses-feature android:name="android.hardware.bluetooth" android:required="true"/>` will be added to the `AndroidManifest.xml`.
+
+- `canDiscover` (_boolean_): default:`true` - Indicates whether your app should have the permission to discover other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADMIN` and `android.permission.BLUETOOTH` are added with specific `android:maxSdkVersion` conditionally based on your settings.
+
+- `isDiscoverable` (_boolean_): default:`false` - Dictates whether or not your app is discoverable to other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADVERTISE` will be added to `AndroidManifest.xml`.
+
+- `canConnect` (_boolean_): default:`true` - Specifies if your app requires the permission to connect to already-paired Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_CONNECT` will be added to `AndroidManifest.xml`.
 
 > Expo SDK 48 supports iOS 13+ which means `NSBluetoothPeripheralUsageDescription` is fully deprecated. It is no longer setup in `@config-plugins/react-native-ble-plx@5.0.0` and greater.
 
@@ -45,9 +57,11 @@ The plugin provides props for extra customization. Every time you change the pro
       [
         "@config-plugins/react-native-ble-plx",
         {
-          "isBackgroundEnabled": true,
+          
           "modes": ["peripheral", "central"],
-          "bluetoothAlwaysPermission": "Allow $(PRODUCT_NAME) to connect to bluetooth devices"
+          "bluetoothAlwaysPermission": "Allow $(PRODUCT_NAME) to connect to bluetooth devices",
+          "neverForLocation": false,
+          "isRequired": true,
         }
       ]
     ]

--- a/packages/react-native-ble-plx/README.md
+++ b/packages/react-native-ble-plx/README.md
@@ -42,7 +42,7 @@ The plugin provides props for extra customization. Every time you change the pro
 
 - `canConnect` (_boolean_): default:`true` - Specifies if your app requires the permission to connect to already-paired Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_CONNECT` will be added to `AndroidManifest.xml`.
 
-- `neverForLocation` (_boolean_): default:`false` - A flag you can set to `true` to assert that your app doesn't use BLE scan results to derive physical location. If `true`, `"android:usesPermissionFlags": "neverForLocation"` will be added to your `"android.permission.BLUETOOTH_SCAN"` declaration. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
+- `neverForLocation` (_boolean_): default:`true` - A flag you can set to `true` to assert that your app doesn't use BLE scan results to derive physical location. If `true`, `"android:usesPermissionFlags": "neverForLocation"` will be added to your `"android.permission.BLUETOOTH_SCAN"` declaration. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
 
 - `isDiscoverable` (_boolean_): default:`false` - Dictates whether or not your app is discoverable to other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADVERTISE` will be added to `AndroidManifest.xml`.
 

--- a/packages/react-native-ble-plx/build/withBLE.d.ts
+++ b/packages/react-native-ble-plx/build/withBLE.d.ts
@@ -2,9 +2,12 @@ import { ConfigPlugin } from "expo/config-plugins";
 import { BackgroundMode } from "./withBLEBackgroundModes";
 export { BackgroundMode };
 declare const _default: ConfigPlugin<void | {
-    isBackgroundEnabled?: boolean | undefined;
     neverForLocation?: boolean | undefined;
     modes?: BackgroundMode[] | undefined;
     bluetoothAlwaysPermission?: string | false | undefined;
+    isRequired?: boolean | undefined;
+    canDiscover?: boolean | undefined;
+    isDiscoverable?: boolean | undefined;
+    canConnect?: boolean | undefined;
 }>;
 export default _default;

--- a/packages/react-native-ble-plx/build/withBLE.js
+++ b/packages/react-native-ble-plx/build/withBLE.js
@@ -12,7 +12,7 @@ const pkg = { name: "react-native-ble-plx", version: "UNVERSIONED" }; //require(
  */
 const withBLE = (config, props = {}) => {
     const _props = props || {};
-    const neverForLocation = _props.neverForLocation ?? false;
+    const neverForLocation = _props.neverForLocation ?? true;
     const isRequired = _props.isRequired ?? false;
     const canDiscover = _props.canDiscover ?? true;
     const isDiscoverable = _props.isDiscoverable ?? false;

--- a/packages/react-native-ble-plx/build/withBLE.js
+++ b/packages/react-native-ble-plx/build/withBLE.js
@@ -12,23 +12,26 @@ const pkg = { name: "react-native-ble-plx", version: "UNVERSIONED" }; //require(
  */
 const withBLE = (config, props = {}) => {
     const _props = props || {};
-    const isBackgroundEnabled = _props.isBackgroundEnabled ?? false;
     const neverForLocation = _props.neverForLocation ?? false;
+    const isRequired = _props.isRequired ?? false;
+    const canDiscover = _props.canDiscover ?? true;
+    const isDiscoverable = _props.isDiscoverable ?? false;
+    const canConnect = _props.canConnect ?? true;
     if ("bluetoothPeripheralPermission" in _props) {
         config_plugins_1.WarningAggregator.addWarningIOS("bluetoothPeripheralPermission", `The iOS permission \`NSBluetoothPeripheralUsageDescription\` is fully deprecated as of iOS 13 (lowest iOS version in Expo SDK 47+). Remove the \`bluetoothPeripheralPermission\` property from the \`@config-plugins/react-native-ble-plx\` config plugin.`);
+    }
+    if ("isBackgroundEnabled" in _props) {
+        config_plugins_1.WarningAggregator.addWarningAndroid("isBackgroundEnabled", "This propery name has changed. You should use isRequired, as better matches the behavior.");
     }
     // iOS
     config = (0, withBluetoothPermissions_1.withBluetoothPermissions)(config, _props);
     config = (0, withBLEBackgroundModes_1.withBLEBackgroundModes)(config, _props.modes || []);
-    // Android
-    config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
-        "android.permission.BLUETOOTH",
-        "android.permission.BLUETOOTH_ADMIN",
-        "android.permission.BLUETOOTH_CONNECT", // since Android SDK 31
-    ]);
     config = (0, withBLEAndroidManifest_1.withBLEAndroidManifest)(config, {
-        isBackgroundEnabled,
         neverForLocation,
+        isRequired,
+        canDiscover,
+        isDiscoverable,
+        canConnect,
     });
     return config;
 };

--- a/packages/react-native-ble-plx/build/withBLEAndroidManifest.d.ts
+++ b/packages/react-native-ble-plx/build/withBLEAndroidManifest.d.ts
@@ -2,25 +2,25 @@ import { AndroidConfig, ConfigPlugin } from "expo/config-plugins";
 type InnerManifest = AndroidConfig.Manifest.AndroidManifest["manifest"];
 type ManifestPermission = InnerManifest["permission"];
 type ExtraTools = {
-  "tools:targetApi"?: string;
+    "tools:targetApi"?: string;
 };
 type ManifestUsesPermissionWithExtraTools = {
-  $: AndroidConfig.Manifest.ManifestUsesPermission["$"] & ExtraTools;
+    $: AndroidConfig.Manifest.ManifestUsesPermission["$"] & ExtraTools;
 };
 type AndroidManifest = {
-  manifest: InnerManifest & {
-    permission?: ManifestPermission;
-    "uses-permission"?: ManifestUsesPermissionWithExtraTools[];
-    "uses-permission-sdk-23"?: ManifestUsesPermissionWithExtraTools[];
-    "uses-feature"?: InnerManifest["uses-feature"];
-  };
+    manifest: InnerManifest & {
+        permission?: ManifestPermission;
+        "uses-permission"?: ManifestUsesPermissionWithExtraTools[];
+        "uses-permission-sdk-23"?: ManifestUsesPermissionWithExtraTools[];
+        "uses-feature"?: InnerManifest["uses-feature"];
+    };
 };
 export declare const withBLEAndroidManifest: ConfigPlugin<{
-  neverForLocation: boolean;
-  isRequired: boolean;
-  canDiscover: boolean;
-  isDiscoverable: boolean;
-  canConnect: boolean;
+    neverForLocation: boolean;
+    isRequired: boolean;
+    canDiscover: boolean;
+    isDiscoverable: boolean;
+    canConnect: boolean;
 }>;
 /**
  * Mutates the given AndroidManifest to add necessary location permissions.
@@ -35,18 +35,9 @@ export declare const withBLEAndroidManifest: ConfigPlugin<{
  *
  * @returns {AndroidManifest} - The updated AndroidManifest with the necessary location permissions added.
  */
-export declare function addLocationPermissionToManifest(
-  androidManifest: AndroidManifest,
-  neverForLocationSinceSdk31: boolean
-): AndroidManifest;
-export declare function addAdminBluetoothPermissionToManifest(
-  androidManifest: AndroidManifest,
-  canDiscover: boolean
-): AndroidManifest;
-export declare function addScanBluetoothPermissionToManifest(
-  androidManifest: AndroidManifest,
-  neverForLocation: boolean
-): AndroidManifest;
+export declare function addLocationPermissionToManifest(androidManifest: AndroidManifest, neverForLocationSinceSdk31: boolean): AndroidManifest;
+export declare function addAdminBluetoothPermissionToManifest(androidManifest: AndroidManifest, canDiscover: boolean): AndroidManifest;
+export declare function addScanBluetoothPermissionToManifest(androidManifest: AndroidManifest, neverForLocation: boolean): AndroidManifest;
 /**
  * Mutates the given AndroidManifest to add the Bluetooth Low Energy (BLE) feature.
  * This is needed if the application always requires BLE.
@@ -55,12 +46,8 @@ export declare function addScanBluetoothPermissionToManifest(
  * @param {AndroidConfig.Manifest.AndroidManifest} androidManifest - The manifest of the Android project.
  * @returns {AndroidConfig.Manifest.AndroidManifest} - The updated AndroidManifest with required BLE feature added.
  */
-export declare function addBLEHardwareFeatureToManifest(
-  androidManifest: AndroidConfig.Manifest.AndroidManifest
-): AndroidConfig.Manifest.AndroidManifest;
-export declare function addConnectBluetoothPermissionToManifest(
-  androidManifest: AndroidConfig.Manifest.AndroidManifest
-): AndroidConfig.Manifest.AndroidManifest;
+export declare function addBLEHardwareFeatureToManifest(androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
+export declare function addConnectBluetoothPermissionToManifest(androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
 /**
  * Mutates the given AndroidManifest to add the 'BLUETOOTH_ADVERTISE' permission.
  *
@@ -72,7 +59,5 @@ export declare function addConnectBluetoothPermissionToManifest(
  *
  * @returns {AndroidConfig.Manifest.AndroidManifest} - The updated AndroidManifest with the Bluetooth advertise permissions added.
  */
-export declare function addBluetoothDiscoverablePermissionToManifest(
-  androidManifest: AndroidManifest
-): AndroidConfig.Manifest.AndroidManifest;
+export declare function addBluetoothDiscoverablePermissionToManifest(androidManifest: AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
 export {};

--- a/packages/react-native-ble-plx/build/withBLEAndroidManifest.d.ts
+++ b/packages/react-native-ble-plx/build/withBLEAndroidManifest.d.ts
@@ -1,35 +1,78 @@
-import { ConfigPlugin, AndroidConfig } from "expo/config-plugins";
+import { AndroidConfig, ConfigPlugin } from "expo/config-plugins";
 type InnerManifest = AndroidConfig.Manifest.AndroidManifest["manifest"];
 type ManifestPermission = InnerManifest["permission"];
 type ExtraTools = {
-    "tools:targetApi"?: string;
+  "tools:targetApi"?: string;
 };
 type ManifestUsesPermissionWithExtraTools = {
-    $: AndroidConfig.Manifest.ManifestUsesPermission["$"] & ExtraTools;
+  $: AndroidConfig.Manifest.ManifestUsesPermission["$"] & ExtraTools;
 };
 type AndroidManifest = {
-    manifest: InnerManifest & {
-        permission?: ManifestPermission;
-        "uses-permission"?: ManifestUsesPermissionWithExtraTools[];
-        "uses-permission-sdk-23"?: ManifestUsesPermissionWithExtraTools[];
-        "uses-feature"?: InnerManifest["uses-feature"];
-    };
+  manifest: InnerManifest & {
+    permission?: ManifestPermission;
+    "uses-permission"?: ManifestUsesPermissionWithExtraTools[];
+    "uses-permission-sdk-23"?: ManifestUsesPermissionWithExtraTools[];
+    "uses-feature"?: InnerManifest["uses-feature"];
+  };
 };
 export declare const withBLEAndroidManifest: ConfigPlugin<{
-    isBackgroundEnabled: boolean;
-    neverForLocation: boolean;
+  neverForLocation: boolean;
+  isRequired: boolean;
+  canDiscover: boolean;
+  isDiscoverable: boolean;
+  canConnect: boolean;
 }>;
 /**
- * Add location permissions
- *  - 'android.permission.ACCESS_COARSE_LOCATION' for Android SDK 28 (Android 9) and lower
- *  - 'android.permission.ACCESS_FINE_LOCATION' for Android SDK 29 (Android 10) and higher.
- *    From Android SDK 31 (Android 12) it might not be required if BLE is not used for location.
+ * Mutates the given AndroidManifest to add necessary location permissions.
+ *
+ * @param {AndroidManifest} androidManifest - The manifest of the Android project.
+ * @param {boolean} neverForLocationSinceSdk31 - Flag to control if location permission is required for Android SDK 31 and higher.
+ *                                               If flag is set, 'ACCESS_FINE_LOCATION' only applies to SDK 30 and lower, else it applies to all.
+ *
+ * 'android.permission.ACCESS_FINE_LOCATION' is included for Android SDK 29 (Android 10) and higher.
+ * However, from Android SDK 31 (Android 12) onwards, it might not be necessary if BLE is not used for location.
+ * More details can be found on: https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#declare-android11-or-lower
+ *
+ * @returns {AndroidManifest} - The updated AndroidManifest with the necessary location permissions added.
  */
-export declare function addLocationPermissionToManifest(androidManifest: AndroidManifest, neverForLocationSinceSdk31: boolean): AndroidManifest;
+export declare function addLocationPermissionToManifest(
+  androidManifest: AndroidManifest,
+  neverForLocationSinceSdk31: boolean
+): AndroidManifest;
+export declare function addAdminBluetoothPermissionToManifest(
+  androidManifest: AndroidManifest,
+  canDiscover: boolean
+): AndroidManifest;
+export declare function addScanBluetoothPermissionToManifest(
+  androidManifest: AndroidManifest,
+  neverForLocation: boolean
+): AndroidManifest;
 /**
- * Add 'android.permission.BLUETOOTH_SCAN'.
- * Required since Android SDK 31 (Android 12).
+ * Mutates the given AndroidManifest to add the Bluetooth Low Energy (BLE) feature.
+ * This is needed if the application always requires BLE.
+ * More info on permissions involving BLE can be found here: https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions
+ *
+ * @param {AndroidConfig.Manifest.AndroidManifest} androidManifest - The manifest of the Android project.
+ * @returns {AndroidConfig.Manifest.AndroidManifest} - The updated AndroidManifest with required BLE feature added.
  */
-export declare function addScanPermissionToManifest(androidManifest: AndroidManifest, neverForLocation: boolean): AndroidManifest;
-export declare function addBLEHardwareFeatureToManifest(androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
+export declare function addBLEHardwareFeatureToManifest(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+): AndroidConfig.Manifest.AndroidManifest;
+export declare function addConnectBluetoothPermissionToManifest(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+): AndroidConfig.Manifest.AndroidManifest;
+/**
+ * Mutates the given AndroidManifest to add the 'BLUETOOTH_ADVERTISE' permission.
+ *
+ * @param {AndroidManifest} androidManifest - The manifest of the Android project.
+ *
+ * This function adds 'android.permission.BLUETOOTH_ADVERTISE' to the AndroidManifest if it doesn't exist.
+ * This permission is needed if your app makes the device discoverable to other Bluetooth devices. It allows the app
+ * to broadcast that it's open for connections to other devices that are scanning for advertisements.
+ *
+ * @returns {AndroidConfig.Manifest.AndroidManifest} - The updated AndroidManifest with the Bluetooth advertise permissions added.
+ */
+export declare function addBluetoothDiscoverablePermissionToManifest(
+  androidManifest: AndroidManifest
+): AndroidConfig.Manifest.AndroidManifest;
 export {};

--- a/packages/react-native-ble-plx/build/withBLEAndroidManifest.js
+++ b/packages/react-native-ble-plx/build/withBLEAndroidManifest.js
@@ -1,91 +1,163 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addBLEHardwareFeatureToManifest = exports.addScanPermissionToManifest = exports.addLocationPermissionToManifest = exports.withBLEAndroidManifest = void 0;
+exports.addBluetoothDiscoverablePermissionToManifest = exports.addConnectBluetoothPermissionToManifest = exports.addBLEHardwareFeatureToManifest = exports.addScanBluetoothPermissionToManifest = exports.addAdminBluetoothPermissionToManifest = exports.addLocationPermissionToManifest = exports.withBLEAndroidManifest = void 0;
 const config_plugins_1 = require("expo/config-plugins");
-const withBLEAndroidManifest = (config, { isBackgroundEnabled, neverForLocation }) => {
+/**
+ * Check if a certain permission exists on the manifest
+ * @param {AndroidManifest} androidManifest - The AndroidManifest object
+ * @param {string} permissionName - The permission to look for
+ * @return {boolean}
+ */
+function isPermissionInManifest(androidManifest, permissionName) {
+    if (Array.isArray(androidManifest.manifest["uses-permission"])) {
+        const foundInUsesPermission = androidManifest.manifest["uses-permission"].find((item) => item.$["android:name"] === permissionName);
+        if (foundInUsesPermission) {
+            return true;
+        }
+    }
+    if (Array.isArray(androidManifest.manifest["uses-permission-sdk-23"])) {
+        const foundInUsesPermissionSDK23 = androidManifest.manifest["uses-permission-sdk-23"].find((item) => item.$["android:name"] === permissionName);
+        if (foundInUsesPermissionSDK23) {
+            return true;
+        }
+    }
+    return false;
+}
+/**
+ * Check if a certain permission exists on the manifest, add if not
+ * @param {AndroidManifest} androidManifest - The AndroidManifest object
+ * @param {string} permissionName - The permission to look for
+ * @param {ManifestUsesPermissionWithExtraTools} permissions - Permissions details
+ * @return {AndroidManifest}
+ */
+function addPermissionToManifestIfNotExists(androidManifest, permissionName, permissions) {
+    const doesPermissionExist = isPermissionInManifest(androidManifest, permissionName);
+    if (!doesPermissionExist) {
+        androidManifest.manifest["uses-permission"] =
+            androidManifest.manifest["uses-permission"] || [];
+        androidManifest.manifest["uses-permission"].push({ $: permissions });
+    }
+    return androidManifest;
+}
+const withBLEAndroidManifest = (config, { neverForLocation, canDiscover, isRequired, isDiscoverable, canConnect }) => {
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
         config.modResults = addLocationPermissionToManifest(config.modResults, neverForLocation);
-        config.modResults = addScanPermissionToManifest(config.modResults, neverForLocation);
-        if (isBackgroundEnabled) {
+        config.modResults = addScanBluetoothPermissionToManifest(config.modResults, neverForLocation);
+        config.modResults = addAdminBluetoothPermissionToManifest(config.modResults, canDiscover);
+        if (isRequired) {
             config.modResults = addBLEHardwareFeatureToManifest(config.modResults);
         }
+        if (canConnect) {
+            config.modResults = addConnectBluetoothPermissionToManifest(config.modResults);
+        }
+        if (isDiscoverable) {
+            config.modResults = addBluetoothDiscoverablePermissionToManifest(config.modResults);
+        }
+        // Add 'android.permission.BLUETOOTH' to the AndroidManifest if it doesn't exist
+        // This permission is required for compatibility with older Android devices
+        config.modResults = addPermissionToManifestIfNotExists(config.modResults, "android.permission.BLUETOOTH", {
+            "android:name": "android.permission.BLUETOOTH",
+            ...{ "android:maxSdkVersion": "30" },
+        });
         return config;
     });
 };
 exports.withBLEAndroidManifest = withBLEAndroidManifest;
 /**
- * Add location permissions
- *  - 'android.permission.ACCESS_COARSE_LOCATION' for Android SDK 28 (Android 9) and lower
- *  - 'android.permission.ACCESS_FINE_LOCATION' for Android SDK 29 (Android 10) and higher.
- *    From Android SDK 31 (Android 12) it might not be required if BLE is not used for location.
+ * Mutates the given AndroidManifest to add necessary location permissions.
+ *
+ * @param {AndroidManifest} androidManifest - The manifest of the Android project.
+ * @param {boolean} neverForLocationSinceSdk31 - Flag to control if location permission is required for Android SDK 31 and higher.
+ *                                               If flag is set, 'ACCESS_FINE_LOCATION' only applies to SDK 30 and lower, else it applies to all.
+ *
+ * 'android.permission.ACCESS_FINE_LOCATION' is included for Android SDK 29 (Android 10) and higher.
+ * However, from Android SDK 31 (Android 12) onwards, it might not be necessary if BLE is not used for location.
+ * More details can be found on: https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#declare-android11-or-lower
+ *
+ * @returns {AndroidManifest} - The updated AndroidManifest with the necessary location permissions added.
  */
 function addLocationPermissionToManifest(androidManifest, neverForLocationSinceSdk31) {
-    if (!Array.isArray(androidManifest.manifest["uses-permission-sdk-23"])) {
-        androidManifest.manifest["uses-permission-sdk-23"] = [];
-    }
-    const optMaxSdkVersion = neverForLocationSinceSdk31
-        ? {
-            "android:maxSdkVersion": "30",
-        }
+    // The 'ACCESS_FINE_LOCATION' permission is optional from Android SDK 31 (Android 12) onwards when BLE is not used for location
+    const optionalMaxVersion = neverForLocationSinceSdk31
+        ? { "android:maxSdkVersion": "30" }
         : {};
-    if (!androidManifest.manifest["uses-permission-sdk-23"].find((item) => item.$["android:name"] === "android.permission.ACCESS_COARSE_LOCATION")) {
-        androidManifest.manifest["uses-permission-sdk-23"].push({
-            $: {
-                "android:name": "android.permission.ACCESS_COARSE_LOCATION",
-                ...optMaxSdkVersion,
-            },
-        });
-    }
-    if (!androidManifest.manifest["uses-permission-sdk-23"].find((item) => item.$["android:name"] === "android.permission.ACCESS_FINE_LOCATION")) {
-        androidManifest.manifest["uses-permission-sdk-23"].push({
-            $: {
-                "android:name": "android.permission.ACCESS_FINE_LOCATION",
-                ...optMaxSdkVersion,
-            },
-        });
-    }
-    return androidManifest;
+    // Add 'android.permission.ACCESS_FINE_LOCATION' to the AndroidManifest if it doesn't exist
+    return addPermissionToManifestIfNotExists(androidManifest, "android.permission.ACCESS_FINE_LOCATION", {
+        "android:name": "android.permission.ACCESS_FINE_LOCATION",
+        ...optionalMaxVersion,
+    });
 }
 exports.addLocationPermissionToManifest = addLocationPermissionToManifest;
-/**
- * Add 'android.permission.BLUETOOTH_SCAN'.
- * Required since Android SDK 31 (Android 12).
- */
-function addScanPermissionToManifest(androidManifest, neverForLocation) {
-    if (!Array.isArray(androidManifest.manifest["uses-permission"])) {
-        androidManifest.manifest["uses-permission"] = [];
-    }
-    if (!androidManifest.manifest["uses-permission"].find((item) => item.$["android:name"] === "android.permission.BLUETOOTH_SCAN")) {
-        config_plugins_1.AndroidConfig.Manifest.ensureToolsAvailable(androidManifest);
-        androidManifest.manifest["uses-permission"]?.push({
-            $: {
-                "android:name": "android.permission.BLUETOOTH_SCAN",
-                ...(neverForLocation
-                    ? {
-                        "android:usesPermissionFlags": "neverForLocation",
-                    }
-                    : {}),
-                "tools:targetApi": "31",
-            },
-        });
-    }
-    return androidManifest;
+function addAdminBluetoothPermissionToManifest(androidManifest, canDiscover) {
+    // Add 'android.permission.BLUETOOTH_ADMIN' to the manifest.
+    // If 'canDiscover' is true, this permission is not restricted to older devices
+    // Need to add permission to support older devices
+    return addPermissionToManifestIfNotExists(androidManifest, "android.permission.BLUETOOTH_ADMIN", {
+        "android:name": "android.permission.BLUETOOTH_ADMIN",
+        ...(canDiscover ? {} : { "android:maxSdkVersion": "30" }),
+    });
 }
-exports.addScanPermissionToManifest = addScanPermissionToManifest;
-// Add this line if your application always requires BLE. More info can be found on: https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions
+exports.addAdminBluetoothPermissionToManifest = addAdminBluetoothPermissionToManifest;
+function addScanBluetoothPermissionToManifest(androidManifest, neverForLocation) {
+    // Add 'android.permission.BLUETOOTH_SCAN' to the AndroidManifest if it doesn't exist
+    return addPermissionToManifestIfNotExists(androidManifest, "android.permission.BLUETOOTH_SCAN", {
+        "android:name": "android.permission.BLUETOOTH_SCAN",
+        ...(neverForLocation
+            ? { "android:usesPermissionFlags": "neverForLocation" }
+            : {}),
+        "tools:targetApi": "31",
+    });
+}
+exports.addScanBluetoothPermissionToManifest = addScanBluetoothPermissionToManifest;
+/**
+ * Mutates the given AndroidManifest to add the Bluetooth Low Energy (BLE) feature.
+ * This is needed if the application always requires BLE.
+ * More info on permissions involving BLE can be found here: https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions
+ *
+ * @param {AndroidConfig.Manifest.AndroidManifest} androidManifest - The manifest of the Android project.
+ * @returns {AndroidConfig.Manifest.AndroidManifest} - The updated AndroidManifest with required BLE feature added.
+ */
 function addBLEHardwareFeatureToManifest(androidManifest) {
-    // Add `<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>` to the AndroidManifest.xml
+    // Check if 'uses-feature' array exists in the AndroidManifest, if not, initialize it
     if (!Array.isArray(androidManifest.manifest["uses-feature"])) {
         androidManifest.manifest["uses-feature"] = [];
     }
-    if (!androidManifest.manifest["uses-feature"].find((item) => item.$["android:name"] === "android.hardware.bluetooth_le")) {
-        androidManifest.manifest["uses-feature"]?.push({
+    // Check if the 'uses-feature' for "android.hardware.bluetooth_le" has already been declared, if not, declare it
+    const isBleFeatureDeclared = androidManifest.manifest["uses-feature"].find((item) => item.$["android:name"] === "android.hardware.bluetooth_le");
+    // If 'android.hardware.bluetooth_le' feature is not declared, we add it into the AndroidManifest
+    if (!isBleFeatureDeclared) {
+        androidManifest.manifest["uses-feature"].push({
             $: {
                 "android:name": "android.hardware.bluetooth_le",
-                "android:required": "true",
+                "android:required": "true", // Set as a required feature
             },
         });
     }
+    // Return the updated AndroidManifest
     return androidManifest;
 }
 exports.addBLEHardwareFeatureToManifest = addBLEHardwareFeatureToManifest;
+function addConnectBluetoothPermissionToManifest(androidManifest) {
+    return addPermissionToManifestIfNotExists(androidManifest, "android.permission.BLUETOOTH_CONNECT", {
+        "android:name": "android.permission.BLUETOOTH_CONNECT",
+    });
+}
+exports.addConnectBluetoothPermissionToManifest = addConnectBluetoothPermissionToManifest;
+/**
+ * Mutates the given AndroidManifest to add the 'BLUETOOTH_ADVERTISE' permission.
+ *
+ * @param {AndroidManifest} androidManifest - The manifest of the Android project.
+ *
+ * This function adds 'android.permission.BLUETOOTH_ADVERTISE' to the AndroidManifest if it doesn't exist.
+ * This permission is needed if your app makes the device discoverable to other Bluetooth devices. It allows the app
+ * to broadcast that it's open for connections to other devices that are scanning for advertisements.
+ *
+ * @returns {AndroidConfig.Manifest.AndroidManifest} - The updated AndroidManifest with the Bluetooth advertise permissions added.
+ */
+function addBluetoothDiscoverablePermissionToManifest(androidManifest) {
+    // Add 'android.permission.BLUETOOTH_ADVERTISE' to the AndroidManifest if it doesn't exist
+    return addPermissionToManifestIfNotExists(androidManifest, "android.permission.BLUETOOTH_ADVERTISE", {
+        "android:name": "android.permission.BLUETOOTH_ADVERTISE",
+    });
+}
+exports.addBluetoothDiscoverablePermissionToManifest = addBluetoothDiscoverablePermissionToManifest;

--- a/packages/react-native-ble-plx/src/__tests__/withBLEAndroidManifest-test.ts
+++ b/packages/react-native-ble-plx/src/__tests__/withBLEAndroidManifest-test.ts
@@ -2,9 +2,11 @@ import { AndroidConfig, XML } from "@expo/config-plugins";
 import { resolve } from "path";
 
 import {
-  addLocationPermissionToManifest,
-  addScanPermissionToManifest,
+  addAdminBluetoothPermissionToManifest,
   addBLEHardwareFeatureToManifest,
+  addConnectBluetoothPermissionToManifest,
+  addLocationPermissionToManifest,
+  addScanBluetoothPermissionToManifest,
 } from "../withBLEAndroidManifest";
 
 const { readAndroidManifestAsync } = AndroidConfig.Manifest;
@@ -15,45 +17,49 @@ describe("addLocationPermissionToManifest", () => {
   it(`adds elements`, async () => {
     let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
     androidManifest = addLocationPermissionToManifest(androidManifest, false);
-    expect(androidManifest.manifest["uses-permission-sdk-23"]).toContainEqual({
-      $: {
-        "android:name": "android.permission.ACCESS_COARSE_LOCATION",
-      },
-    });
-    expect(androidManifest.manifest["uses-permission-sdk-23"]).toContainEqual({
+
+    expect(androidManifest.manifest["uses-permission"]).toContainEqual({
       $: {
         "android:name": "android.permission.ACCESS_FINE_LOCATION",
       },
     });
-    // Sanity
+
     expect(XML.format(androidManifest)).toMatch(
-      /<uses-permission-sdk-23 android:name="android\.permission\.ACCESS_COARSE_LOCATION"\/>/
-    );
-    expect(XML.format(androidManifest)).toMatch(
-      /<uses-permission-sdk-23 android:name="android\.permission\.ACCESS_FINE_LOCATION"\/>/
+      /<uses-permission android:name="android\.permission\.ACCESS_FINE_LOCATION"\/>/
     );
   });
+
   it(`adds elements with SDK limit`, async () => {
     let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
     androidManifest = addLocationPermissionToManifest(androidManifest, true);
-    expect(androidManifest.manifest["uses-permission-sdk-23"]).toContainEqual({
-      $: {
-        "android:name": "android.permission.ACCESS_COARSE_LOCATION",
-        "android:maxSdkVersion": "30",
-      },
-    });
-    expect(androidManifest.manifest["uses-permission-sdk-23"]).toContainEqual({
+
+    expect(androidManifest.manifest["uses-permission"]).toContainEqual({
       $: {
         "android:name": "android.permission.ACCESS_FINE_LOCATION",
         "android:maxSdkVersion": "30",
       },
     });
+
+    expect(XML.format(androidManifest)).toMatch(
+      /<uses-permission android:name="android\.permission\.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"\/>/
+    );
+  });
+});
+
+describe("addConnectionPermissionToManifest", () => {
+  it(`adds element`, async () => {
+    let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifest = addConnectBluetoothPermissionToManifest(androidManifest);
+
+    expect(androidManifest.manifest["uses-permission"]).toContainEqual({
+      $: {
+        "android:name": "android.permission.BLUETOOTH_CONNECT",
+      },
+    });
+
     // Sanity
     expect(XML.format(androidManifest)).toMatch(
-      /<uses-permission-sdk-23 android:name="android\.permission\.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30"\/>/
-    );
-    expect(XML.format(androidManifest)).toMatch(
-      /<uses-permission-sdk-23 android:name="android\.permission\.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"\/>/
+      /<uses-permission android:name="android\.permission\.BLUETOOTH_CONNECT"\/>/
     );
   });
 });
@@ -61,21 +67,31 @@ describe("addLocationPermissionToManifest", () => {
 describe("addScanPermissionToManifest", () => {
   it(`adds element`, async () => {
     let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
-    androidManifest = addScanPermissionToManifest(androidManifest, false);
+    androidManifest = addScanBluetoothPermissionToManifest(
+      androidManifest,
+      false
+    );
+
     expect(androidManifest.manifest["uses-permission"]).toContainEqual({
       $: {
         "android:name": "android.permission.BLUETOOTH_SCAN",
         "tools:targetApi": "31",
       },
     });
+
     // Sanity
     expect(XML.format(androidManifest)).toMatch(
       /<uses-permission android:name="android\.permission\.BLUETOOTH_SCAN" tools:targetApi="31"\/>/
     );
   });
-  it(`adds element with 'neverForLocation' attribute`, async () => {
+
+  it(`adds element neverForLocation`, async () => {
     let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
-    androidManifest = addScanPermissionToManifest(androidManifest, true);
+    androidManifest = addScanBluetoothPermissionToManifest(
+      androidManifest,
+      true
+    );
+
     expect(androidManifest.manifest["uses-permission"]).toContainEqual({
       $: {
         "android:name": "android.permission.BLUETOOTH_SCAN",
@@ -83,9 +99,49 @@ describe("addScanPermissionToManifest", () => {
         "tools:targetApi": "31",
       },
     });
+
     // Sanity
     expect(XML.format(androidManifest)).toMatch(
       /<uses-permission android:name="android\.permission\.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" tools:targetApi="31"\/>/
+    );
+  });
+});
+
+describe("addAdminPermissionToManifest", () => {
+  it(`adds element`, async () => {
+    let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifest = addAdminBluetoothPermissionToManifest(
+      androidManifest,
+      false
+    );
+
+    expect(androidManifest.manifest["uses-permission"]).toContainEqual({
+      $: {
+        "android:name": "android.permission.BLUETOOTH_ADMIN",
+        "android:maxSdkVersion": "30",
+      },
+    });
+
+    expect(XML.format(androidManifest)).toMatch(
+      /<uses-permission android:name="android\.permission\.BLUETOOTH_ADMIN" android:maxSdkVersion="30"\/>/
+    );
+  });
+
+  it("adds elmeent with canDiscover = true", async () => {
+    let androidManifest = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifest = addAdminBluetoothPermissionToManifest(
+      androidManifest,
+      true
+    );
+
+    expect(androidManifest.manifest["uses-permission"]).toContainEqual({
+      $: {
+        "android:name": "android.permission.BLUETOOTH_ADMIN",
+      },
+    });
+
+    expect(XML.format(androidManifest)).toMatch(
+      /<uses-permission android:name="android\.permission\.BLUETOOTH_ADMIN"\/>/
     );
   });
 });

--- a/packages/react-native-ble-plx/src/withBLE.ts
+++ b/packages/react-native-ble-plx/src/withBLE.ts
@@ -30,7 +30,7 @@ const withBLE: ConfigPlugin<
 > = (config, props = {}) => {
   const _props = props || {};
 
-  const neverForLocation = _props.neverForLocation ?? false;
+  const neverForLocation = _props.neverForLocation ?? true;
   const isRequired = _props.isRequired ?? false;
   const canDiscover = _props.canDiscover ?? true;
   const isDiscoverable = _props.isDiscoverable ?? false;

--- a/packages/react-native-ble-plx/src/withBLE.ts
+++ b/packages/react-native-ble-plx/src/withBLE.ts
@@ -1,5 +1,4 @@
 import {
-  AndroidConfig,
   ConfigPlugin,
   createRunOncePlugin,
   WarningAggregator,
@@ -19,15 +18,23 @@ const pkg = { name: "react-native-ble-plx", version: "UNVERSIONED" }; //require(
  */
 const withBLE: ConfigPlugin<
   {
-    isBackgroundEnabled?: boolean;
     neverForLocation?: boolean;
     modes?: BackgroundMode[];
     bluetoothAlwaysPermission?: string | false;
+
+    isRequired?: boolean;
+    canDiscover?: boolean;
+    isDiscoverable?: boolean;
+    canConnect?: boolean;
   } | void
 > = (config, props = {}) => {
   const _props = props || {};
-  const isBackgroundEnabled = _props.isBackgroundEnabled ?? false;
+
   const neverForLocation = _props.neverForLocation ?? false;
+  const isRequired = _props.isRequired ?? false;
+  const canDiscover = _props.canDiscover ?? true;
+  const isDiscoverable = _props.isDiscoverable ?? false;
+  const canConnect = _props.canConnect ?? true;
 
   if ("bluetoothPeripheralPermission" in _props) {
     WarningAggregator.addWarningIOS(
@@ -36,19 +43,23 @@ const withBLE: ConfigPlugin<
     );
   }
 
+  if ("isBackgroundEnabled" in _props) {
+    WarningAggregator.addWarningAndroid(
+      "isBackgroundEnabled",
+      "This propery name has changed. You should use isRequired, as better matches the behavior."
+    );
+  }
+
   // iOS
   config = withBluetoothPermissions(config, _props);
   config = withBLEBackgroundModes(config, _props.modes || []);
 
-  // Android
-  config = AndroidConfig.Permissions.withPermissions(config, [
-    "android.permission.BLUETOOTH",
-    "android.permission.BLUETOOTH_ADMIN",
-    "android.permission.BLUETOOTH_CONNECT", // since Android SDK 31
-  ]);
   config = withBLEAndroidManifest(config, {
-    isBackgroundEnabled,
     neverForLocation,
+    isRequired,
+    canDiscover,
+    isDiscoverable,
+    canConnect,
   });
 
   return config;


### PR DESCRIPTION
# Why

Android permissions do not follow official [Android Bluetooth Permissions](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions) docs and react-native-ble-plx. Also, it should allow more granular control over which permissions are added based on the BLE usage. Issue  #149 goes over some of the permissions' challenges and inconsistencies.

# How

On a very high level, the permissions now follow this sample manifest and closely follows settings based on the comments.

```yaml
<manifest>
    <!-- Request legacy Bluetooth permissions on older devices. -->
    <uses-permission android:name="android.permission.BLUETOOTH"
                     android:maxSdkVersion="30" />
    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
                     android:maxSdkVersion="30" />

    <!-- Needed only if your app looks for Bluetooth devices.
         If your app doesn't use Bluetooth scan results to derive physical
         location information, you can strongly assert that your app
         doesn't derive physical location. -->
    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />

    <!-- Needed only if your app makes the device discoverable to Bluetooth
         devices. -->
    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />

    <!-- Needed only if your app communicates with already-paired Bluetooth
         devices. -->
    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />

    <!-- Needed only if your app uses Bluetooth scan results to derive physical location. -->
    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
    ...
</manifest>
```

Options have been renamed and changed, and I implemented some warnings about this, which I have updated on the readme.

Here are the following options and an overview of what they are doing.

### Android options

- `canDiscover` (_boolean_): default:`true` - Indicates whether your app should have the permission to discover other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADMIN` and `android:maxSdkVersion` is added conditioanlly based on legacy Android support. conditionally based on your settings.

- `canConnect` (_boolean_): default:`true` - Specifies if your app requires the permission to connect to already-paired Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_CONNECT` will be added to `AndroidManifest.xml`.

- `neverForLocation` (_boolean_): default:`false` - A flag you can set to `true` to assert that your app doesn't use BLE scan results to derive physical location. If `true`, `"android:usesPermissionFlags": "neverForLocation"` will be added to your `"android.permission.BLUETOOTH_SCAN"` declaration. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._

- `isDiscoverable` (_boolean_): default:`false` - Dictates whether or not your app is discoverable to other Bluetooth devices. If set to `true`, `android.permission.BLUETOOTH_ADVERTISE` will be added to `AndroidManifest.xml`.

- `isRequired` (_boolean_): default:`false` - Determines whether or not your app requires Bluetooth to function. If set to `true`, `<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>` will be added to the `AndroidManifest.xml`.

The user most likely will have to do a `npx expo prebuild --clean`

# Test Plan

I have implemented test for all the changes. But it would not hurt to do a quick spot check. 