### PR TITLE
fix(react-native-branch): Re-init branch session when resumed from background

### DIFF
--- a/packages/react-native-branch/android/src/main/java/expo/modules/adapters/branch/BranchReactActivityLifecycleListener.kt
+++ b/packages/react-native-branch/android/src/main/java/expo/modules/adapters/branch/BranchReactActivityLifecycleListener.kt
@@ -9,7 +9,7 @@ import io.branch.rnbranch.RNBranchModule
 
 
 class BranchReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
-    override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
+    override fun onResume(activity: Activity) {
         RNBranchModule.initSession(activity.getIntent().getData(), activity);
     }
 


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

The react-native-branch plugin used the `OnCreate` lifecycle hook to call `RNBranchModule.InitSession`. This caused the session to only be initialized on first start of the application and not when switching from foreground to background.

# How

 According to the [official docs](https://help.branch.io/developers-hub/docs/react-native) you should use the `OnStart` hook to intialize Branch, but as this does not exists on `ReactActivityLifecycleListener` `onResume` was the closest one.

# Test Plan
Tried to send an event to branch from react-native with
```
const event = new BranchEvent('TEST');
event.logEvent();
```
I used Android studio to monitor network traffic and see that the event is sent to Branch.

Before this fix this stopped working if the app was sent to the background and later resumed.
