### PR TITLE
feat(tv): Fix Android manifest for TV

### DIFF
--- a/packages/tv/package.json
+++ b/packages/tv/package.json
@@ -36,6 +36,7 @@
     "expo": "^50"
   },
   "devDependencies": {
+    "@types/getenv": "^1.0.1",
     "expo-module-scripts": "^3.0.3"
   },
   "upstreamPackage": "tv",

--- a/packages/tv/src/__tests__/__snapshots__/withTV-test.ts.snap
+++ b/packages/tv/src/__tests__/__snapshots__/withTV-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`withTV tests Add TV Podfile changes 1`] = `
+exports[`withTV iOS/tvOS tests Add TV Podfile changes 1`] = `
 "# @generated begin react-native-tvos-import - expo prebuild (DO NOT MODIFY) sync-45ad7228312d07c1751c6969560a210e8ec46f80
 source 'https://github.com/react-native-tvos/react-native-tvos-podspecs.git'
 source 'https://cdn.cocoapods.org/'
@@ -17,7 +17,7 @@ end
 "
 `;
 
-exports[`withTV tests Add TV splash screen changes 1`] = `
+exports[`withTV iOS/tvOS tests Add TV splash screen changes 1`] = `
 "
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="16096" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EXPO-VIEWCONTROLLER-1">

--- a/packages/tv/src/__tests__/fixtures/react-native-AndroidManifest.xml
+++ b/packages/tv/src/__tests__/fixtures/react-native-AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <queries>
+        <!-- Support checking for http(s) links via the Linking API -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize" android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>

--- a/packages/tv/src/__tests__/fixtures/react-native-AndroidManifestWithNoMainIntent.xml
+++ b/packages/tv/src/__tests__/fixtures/react-native-AndroidManifestWithNoMainIntent.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <queries>
+        <!-- Support checking for http(s) links via the Linking API -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>

--- a/packages/tv/src/__tests__/withTV-test.ts
+++ b/packages/tv/src/__tests__/withTV-test.ts
@@ -105,26 +105,21 @@ describe("withTV iOS/tvOS tests", () => {
 describe("with TV Android tests", () => {
   test("Adds leanback launcher intent category for TV builds", async () => {
     const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
-    const modifiedManifest = setLeanBackLauncherIntent({}, originalManifest, {
-      isTV: true,
-    });
+    const modifiedManifest = setLeanBackLauncherIntent(
+      {},
+      originalManifest,
+      false
+    );
     expect(JSON.stringify(modifiedManifest).indexOf("LEANBACK")).not.toEqual(
       -1
     );
-  });
-  test("Does not add leanback launcher category for phone builds", async () => {
-    const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
-    const modifiedManifest = setLeanBackLauncherIntent({}, originalManifest, {
-      isTV: false,
-    });
-    expect(JSON.stringify(modifiedManifest).indexOf("LEANBACK")).toEqual(-1);
   });
   test("Throws if manifest has no main intent", async () => {
     const originalManifest = await readAndroidManifestAsync(
       sampleManifestWithNoMainIntentPath
     );
     try {
-      setLeanBackLauncherIntent({}, originalManifest, { isTV: true });
+      setLeanBackLauncherIntent({}, originalManifest, false);
       // Should not reach this line
       expect(true).toBe(false);
     } catch (e) {
@@ -133,26 +128,15 @@ describe("with TV Android tests", () => {
       );
     }
   });
-  test("Removes orientation from activity metadata if TV enabled", async () => {
+  test("Removes orientation from activity metadata for TV builds", async () => {
     const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
     const modifiedManifest = await removePortraitOrientation(
       {},
       originalManifest,
-      { isTV: true }
+      false
     );
     expect(
       JSON.stringify(modifiedManifest).indexOf("screenOrientation")
     ).toEqual(-1);
-  });
-  test("Does not remove orientation from activity metadata if TV disabled", async () => {
-    const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
-    const modifiedManifest = await removePortraitOrientation(
-      {},
-      originalManifest,
-      { isTV: false }
-    );
-    expect(
-      JSON.stringify(modifiedManifest).indexOf("screenOrientation")
-    ).not.toEqual(-1);
   });
 });

--- a/packages/tv/src/utils.ts
+++ b/packages/tv/src/utils.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { boolish } from "getenv";
 
 import { ConfigData } from "./types";

--- a/packages/tv/src/withTV.ts
+++ b/packages/tv/src/withTV.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin, createRunOncePlugin } from "expo/config-plugins";
 
 import { ConfigData } from "./types";
+import { withTVAndroidManifest } from "./withTVAndroidManifest";
 import { withTVPodfile } from "./withTVPodfile";
 import { withTVSplashScreen } from "./withTVSplashScreen";
 import { withTVXcodeProject } from "./withTVXcodeProject";
@@ -9,6 +10,7 @@ const withTVPlugin: ConfigPlugin<ConfigData> = (config, params = {}) => {
   config = withTVXcodeProject(config, params);
   config = withTVPodfile(config, params);
   config = withTVSplashScreen(config, params);
+  config = withTVAndroidManifest(config, params);
 
   return config;
 };

--- a/packages/tv/src/withTVAndroidManifest.ts
+++ b/packages/tv/src/withTVAndroidManifest.ts
@@ -1,0 +1,130 @@
+import { ExpoConfig } from "expo/config";
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  WarningAggregator,
+  withAndroidManifest,
+} from "expo/config-plugins";
+
+import { ConfigData } from "./types";
+import { isTVEnabled, showVerboseWarnings } from "./utils";
+
+const pkg = require("../package.json");
+
+const { getMainActivity } = AndroidConfig.Manifest;
+
+export const withTVAndroidManifest: ConfigPlugin<ConfigData> = (
+  config,
+  params = {}
+) => {
+  const isTV = isTVEnabled(params);
+  const verbose = showVerboseWarnings(params);
+
+  return withAndroidManifest(config, async (config) => {
+    if (isTV) {
+      if (verbose) {
+        WarningAggregator.addWarningAndroid(
+          "manifest",
+          `${pkg.name}@${pkg.version}: modifying AndroidManifest.xml for TV`
+        );
+      }
+      config.modResults = await setLeanBackLauncherIntent(
+        config,
+        config.modResults,
+        params
+      );
+      config.modResults = await removePortraitOrientation(
+        config,
+        config.modResults,
+        params
+      );
+    }
+    return config;
+  });
+};
+
+const LEANBACK_LAUNCHER_CATEGORY = "android.intent.category.LEANBACK_LAUNCHER";
+
+function getMainLaunchIntent(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+) {
+  const mainActivity = getMainActivity(androidManifest);
+  const intentFilters = mainActivity?.["intent-filter"];
+  const mainLaunchIntents = (intentFilters ?? []).filter((i) => {
+    const action = i.action ?? [];
+    if (action.length === 0) {
+      return false;
+    }
+    return action[0]?.$["android:name"] === "android.intent.action.MAIN";
+  });
+  return mainLaunchIntents.length ? mainLaunchIntents[0] : undefined;
+}
+
+function leanbackLauncherCategoryExistsInMainLaunchIntent(
+  mainLaunchIntent: AndroidConfig.Manifest.ManifestIntentFilter
+): boolean {
+  const mainLaunchCategories = mainLaunchIntent.category ?? [];
+  const mainLaunchIntentCategoriesWithLeanbackLauncher =
+    mainLaunchCategories.filter(
+      (c) => c.$["android:name"] === LEANBACK_LAUNCHER_CATEGORY
+    );
+  return mainLaunchIntentCategoriesWithLeanbackLauncher.length > 0;
+}
+
+export function setLeanBackLauncherIntent(
+  _config: Pick<ExpoConfig, "android">,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  params: ConfigData
+): AndroidConfig.Manifest.AndroidManifest {
+  const isTV = isTVEnabled(params);
+  const verbose = showVerboseWarnings(params);
+  if (isTV) {
+    const mainLaunchIntent = getMainLaunchIntent(androidManifest);
+    if (!mainLaunchIntent) {
+      throw new Error(
+        `${pkg.name}@${pkg.version}: no main intent in main activity of Android manifest`
+      );
+    }
+    if (!leanbackLauncherCategoryExistsInMainLaunchIntent(mainLaunchIntent)) {
+      // Leanback needs to be added
+      if (verbose) {
+        WarningAggregator.addWarningAndroid(
+          "manifest",
+          `${pkg.name}@${pkg.version}: adding TV leanback launcher category to main intent in AndroidManifest.xml`
+        );
+      }
+      const mainLaunchCategories = mainLaunchIntent.category ?? [];
+      mainLaunchCategories.push({
+        $: {
+          "android:name": LEANBACK_LAUNCHER_CATEGORY,
+        },
+      });
+      mainLaunchIntent.category = mainLaunchCategories;
+    }
+  }
+  return androidManifest;
+}
+
+export async function removePortraitOrientation(
+  _config: Pick<ExpoConfig, "android">,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  params: ConfigData
+): Promise<AndroidConfig.Manifest.AndroidManifest> {
+  const isTV = isTVEnabled(params);
+  const verbose = showVerboseWarnings(params);
+
+  const mainActivity = getMainActivity(androidManifest);
+  if (mainActivity?.$) {
+    const metadata: typeof mainActivity.$ = mainActivity?.$ ?? {};
+    if (metadata["android:screenOrientation"] && isTV) {
+      if (verbose) {
+        WarningAggregator.addWarningAndroid(
+          "manifest",
+          `${pkg.name}@${pkg.version}: removing screen orientation from AndroidManifest.xml`
+        );
+      }
+      delete metadata["android:screenOrientation"];
+    }
+  }
+  return androidManifest;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,6 +3494,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/getenv@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/getenv/-/getenv-1.0.1.tgz#8af7875951d0c7371579dbb6df58228cf8695f36"
+  integrity sha512-wEibX1AwJNToJm0sSEXbkpngDYrOaS0F1MkfwNJhHR8tIVrRAIah1+PzYRtNae5Ci9jAijrbJfKC6QEbtIVMag==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1", "@types/glob@^7.1.3":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -8220,7 +8227,44 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@9.0.0, fs-extra@^11.0.0, fs-extra@^7.0.0, fs-extra@^8.1.0, fs-extra@^9.0.0, fs-extra@^9.1.0, fs-extra@~8.1.0:
+fs-extra@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
+fs-extra@^11.0.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^8.1.0, fs-extra@~8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^9.0.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -10567,6 +10611,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -16469,6 +16520,16 @@ universal-user-agent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Why

TV builds for Android need to include an intent for the app to show up in the TV launcher, and should not have phone screen orientation.

# How

- Remove android:screenOrientation from activity attributes if TV enabled
- Add leanback launcher to main intent for TV

# Test Plan

- Unit tests added
- Tested with sample app
