### PR TITLE
[docs] Update React Native Firebase plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here is a list of known packages that have a built-in Config Plugin.
 
 > Not all packages need a config plugin, packages that don't appear here might still work with managed EAS.
 
-- [React Native Firebase](https://rnfirebase.io/) (`@react-native-firebase/perf`, `@react-native-firebase/app`)
+- [React Native Firebase](https://rnfirebase.io/) (`@react-native-firebase/perf`, `@react-native-firebase/app`, `@react-native-firebase/crashlytics`)
 - [react-native-nfc-manager](https://github.com/revtel/react-native-nfc-manager)
 - [react-native-health](https://github.com/agencyenterprise/react-native-health)
 - [@react-native-mapbox-gl/maps](https://github.com/rnmapbox/maps)


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why & How

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The React Native Firebase is missing `"@react-native-firebase/crashlytics"` from the list and can be confusing as to why there is a parity between this doc and the actual React Native Firebase docs: https://rnfirebase.io/#expo-managed-workflow

