### PR TITLE
fix: AGP 8 compatibility for react-native-branch

### DIFF
--- a/packages/react-native-branch/android/build.gradle
+++ b/packages/react-native-branch/android/build.gradle
@@ -37,13 +37,17 @@ buildscript {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   defaultConfig {


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

```
[RUN_GRADLEW] Execution failed for task ':config-plugins-react-native-branch:compileDebugKotlin'.
[RUN_GRADLEW] > 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.
[RUN_GRADLEW]   Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

https://github.com/expo/fyi/blob/main/expo-modules-gradle8-migration.md#error-task-current-target-is-17-and-compilereleasekotlin-task-current-target-is-11-jvm-target-compatibility-should-be-set-to-the-same-java-version

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The app properly compiles on SDK 50
