### PR TITLE
fix: update callkeep to support newer android targetSdks

### DIFF
--- a/packages/react-native-callkeep/src/withCallkeep.ts
+++ b/packages/react-native-callkeep/src/withCallkeep.ts
@@ -69,10 +69,7 @@ const withAndroidManifestService: ConfigPlugin = (config) => {
           "android:label": "Wazo",
           "android:permission":
             "android.permission.BIND_TELECOM_CONNECTION_SERVICE",
-          // Use this to target android >= 11
-          // "android:foregroundServiceType": "camera|microphone",
-          // For android < 11
-          "android:foregroundServiceType": "phoneCall",
+          "android:foregroundServiceType": "camera|microphone",
         },
         "intent-filter": [
           {


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

According to the [callkeep library](https://github.com/react-native-webrtc/react-native-callkeep/blob/master/docs/android-installation.md#android-common-step-installation) to target android versions > 11, `android:foregroundServiceType="camera|microphone"` must be used

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
