### PR TITLE
chore(adjust): update play services to ads-identidier

### DIFF
--- a/packages/react-native-adjust/src/withReactNativeAdjust.ts
+++ b/packages/react-native-adjust/src/withReactNativeAdjust.ts
@@ -34,7 +34,7 @@ const addAndroidPackagingOptions = (src: string) => {
     tag: "react-native-play-services-analytics",
     src,
     newSrc: `
-      implementation 'com.google.android.gms:play-services-analytics:18.0.1'
+      implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
       implementation 'com.android.installreferrer:installreferrer:2.2'
     `,
     anchor: /dependencies(?:\s+)?\{/,


### PR DESCRIPTION
# Why

Adjust docs are changed and now it's recommended to use 'com.google.android.gms:play-services-ads-identifier:18.0.1'
![image](https://github.com/expo/config-plugins/assets/17152409/0ca3dff1-5ab9-44da-b42e-bf6769b1fdab)

Also, google services analytics is deprecated:
![image](https://github.com/expo/config-plugins/assets/17152409/f30b5c76-4f53-4d24-9c0b-82e28d5cbf15)


# Test Plan

- Run `expo prebuild`

![image](https://github.com/expo/config-plugins/assets/17152409/4986096a-2249-48fa-b6d6-fd5fab407a00)
