### PR TITLE
feat(branch): add support for test environments

### DIFF
--- a/packages/react-native-branch/ios/ExpoAdapterBranch/BranchAppDelegate.swift
+++ b/packages/react-native-branch/ios/ExpoAdapterBranch/BranchAppDelegate.swift
@@ -3,6 +3,10 @@ import RNBranch
 
 public class BranchAppDelegate: ExpoAppDelegateSubscriber {
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    if Bundle.main.object(forInfoDictionaryKey: "branch_test_environment") as? Bool ?? false {
+      RNBranch.useTestInstance()
+    }
+    
     RNBranch.initSession(launchOptions: launchOptions, isReferrable: true)
     return true
   }

--- a/packages/react-native-branch/src/__tests__/withBranchAndroid-test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchAndroid-test.ts
@@ -1,7 +1,7 @@
 import { AndroidConfig } from "@expo/config-plugins";
 import { resolve } from "path";
 
-import { getBranchApiKey, setBranchApiKey } from "../withBranchAndroid";
+import { setBranchApiKeys, setBranchTestMode } from "../withBranchAndroid";
 
 const { findMetaDataItem, getMainApplication, readAndroidManifestAsync } =
   AndroidConfig.Manifest;
@@ -9,44 +9,51 @@ const { findMetaDataItem, getMainApplication, readAndroidManifestAsync } =
 const sampleManifestPath = resolve(
   __dirname,
   "./fixtures",
-  "react-native-AndroidManifest.xml",
+  "react-native-AndroidManifest.xml"
 );
 
-describe(getBranchApiKey, () => {
-  it(`returns null if no android branch api key is provided`, () => {
-    expect(getBranchApiKey({ android: { config: {} } } as any)).toBe(null);
-  });
-
-  it(`returns apikey if android branch api key is provided`, () => {
-    expect(
-      getBranchApiKey({
-        android: { config: { branch: { apiKey: "MY-API-KEY" } } },
-      } as any),
-    ).toBe("MY-API-KEY");
-  });
-});
-
-describe(setBranchApiKey, () => {
+describe(setBranchApiKeys, () => {
   it("sets branch api key in AndroidManifest.xml if given", async () => {
     let androidManifestJson =
       await readAndroidManifestAsync(sampleManifestPath);
-    androidManifestJson = await setBranchApiKey(
-      "MY-API-KEY",
-      androidManifestJson,
+    androidManifestJson = await setBranchApiKeys(
+      { apiKey: "MY-API-KEY", testApiKey: "MY-TEST-API-KEY" },
+      androidManifestJson
     );
     let mainApplication = getMainApplication(androidManifestJson);
 
     expect(
-      findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey"),
+      findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey")
+    ).toBeGreaterThan(-1);
+    expect(
+      findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey.test")
     ).toBeGreaterThan(-1);
 
     // Unset the item
 
-    androidManifestJson = await setBranchApiKey(null, androidManifestJson);
+    androidManifestJson = await setBranchApiKeys({}, androidManifestJson);
     mainApplication = getMainApplication(androidManifestJson);
 
     expect(findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey")).toBe(
-      -1,
+      -1
     );
+    expect(
+      findMetaDataItem(mainApplication, "io.branch.sdk.BranchKey.test")
+    ).toBe(-1);
+  });
+});
+
+describe(setBranchTestMode, () => {
+  it("sets branch test mode meta data item in AndroidManifest.xml", async () => {
+    let androidManifestJson =
+      await readAndroidManifestAsync(sampleManifestPath);
+
+    androidManifestJson = await setBranchTestMode(true, androidManifestJson);
+
+    const mainApplication = getMainApplication(androidManifestJson);
+
+    expect(
+      findMetaDataItem(mainApplication, "io.branch.sdk.TestMode")
+    ).toBeGreaterThan(-1);
   });
 });

--- a/packages/react-native-branch/src/__tests__/withBranchAndroid-test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchAndroid-test.ts
@@ -1,7 +1,10 @@
 import { AndroidConfig } from "@expo/config-plugins";
 import { resolve } from "path";
 
-import { setBranchApiKeys, setBranchTestMode } from "../withBranchAndroid";
+import {
+  setBranchApiKeys,
+  enableBranchTestEnvironment,
+} from "../withBranchAndroid";
 
 const { findMetaDataItem, getMainApplication, readAndroidManifestAsync } =
   AndroidConfig.Manifest;
@@ -43,12 +46,15 @@ describe(setBranchApiKeys, () => {
   });
 });
 
-describe(setBranchTestMode, () => {
+describe(enableBranchTestEnvironment, () => {
   it("sets branch test mode meta data item in AndroidManifest.xml", async () => {
     let androidManifestJson =
       await readAndroidManifestAsync(sampleManifestPath);
 
-    androidManifestJson = await setBranchTestMode(true, androidManifestJson);
+    androidManifestJson = await enableBranchTestEnvironment(
+      true,
+      androidManifestJson
+    );
 
     const mainApplication = getMainApplication(androidManifestJson);
 

--- a/packages/react-native-branch/src/__tests__/withBranchIOS-test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchIOS-test.ts
@@ -1,27 +1,33 @@
-import { getBranchApiKey, setBranchApiKey } from "../withBranchIOS";
+import { setBranchApiKeys, setBranchTestMode } from "../withBranchIOS";
 
-describe(getBranchApiKey, () => {
-  it(`returns null if no api key is provided`, () => {
-    expect(getBranchApiKey({})).toBe(null);
-  });
-
-  it(`returns the api key if provided`, () => {
-    expect(
-      getBranchApiKey({ ios: { config: { branch: { apiKey: "123" } } } }),
-    ).toBe("123");
-  });
-});
-
-describe(setBranchApiKey, () => {
+describe(setBranchApiKeys, () => {
   it(`sets branch_key.live if the api key is given`, () => {
-    expect(setBranchApiKey("123", {})).toMatchObject({
+    expect(setBranchApiKeys({ apiKey: "LIVE-API-KEY" }, {})).toMatchObject({
       branch_key: {
-        live: "123",
+        live: "LIVE-API-KEY",
       },
     });
   });
 
-  it(`makes no changes to the infoPlist no api key is provided`, () => {
-    expect(setBranchApiKey(null, {})).toMatchObject({});
+  it(`sets branch_key.test if the test api key is given`, () => {
+    expect(
+      setBranchApiKeys(
+        { apiKey: "LIVE-API-KEY", testApiKey: "TEST-API-KEY" },
+        {}
+      )
+    ).toMatchObject({
+      branch_key: {
+        live: "LIVE-API-KEY",
+        test: "TEST-API-KEY",
+      },
+    });
+  });
+});
+
+describe(setBranchTestMode, () => {
+  it(`must assign the passed boolean value into branch_key.branch_test_mode`, () => {
+    expect(setBranchTestMode(true, {})).toMatchObject({
+      branch_test_environment: true,
+    });
   });
 });

--- a/packages/react-native-branch/src/__tests__/withBranchIOS-test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchIOS-test.ts
@@ -1,4 +1,7 @@
-import { setBranchApiKeys, setBranchTestMode } from "../withBranchIOS";
+import {
+  setBranchApiKeys,
+  enableBranchTestEnvironment,
+} from "../withBranchIOS";
 
 describe(setBranchApiKeys, () => {
   it(`sets branch_key.live if the api key is given`, () => {
@@ -24,9 +27,9 @@ describe(setBranchApiKeys, () => {
   });
 });
 
-describe(setBranchTestMode, () => {
+describe(enableBranchTestEnvironment, () => {
   it(`must assign the passed boolean value into branch_key.branch_test_mode`, () => {
-    expect(setBranchTestMode(true, {})).toMatchObject({
+    expect(enableBranchTestEnvironment(true, {})).toMatchObject({
       branch_test_environment: true,
     });
   });

--- a/packages/react-native-branch/src/types.ts
+++ b/packages/react-native-branch/src/types.ts
@@ -1,5 +1,12 @@
 export type ConfigData = {
   apiKey?: string;
+  testApiKey?: string;
   iosAppDomain?: string;
   iosUniversalLinkDomains?: string[];
+  enableTestEnvironment?: boolean;
+};
+
+export type BranchKeys = {
+  apiKey: string;
+  testApiKey?: string;
 };

--- a/packages/react-native-branch/src/withBranch.ts
+++ b/packages/react-native-branch/src/withBranch.ts
@@ -4,22 +4,17 @@ import { ConfigData } from "./types";
 import { withBranchAndroid } from "./withBranchAndroid";
 import { withBranchIOS } from "./withBranchIOS";
 
-const withBranch: ConfigPlugin<ConfigData> = (
-  config,
-  { apiKey, iosAppDomain, iosUniversalLinkDomains } = {},
-) => {
-  config = withBranchAndroid(config, { apiKey });
-  config = withBranchIOS(config, {
-    apiKey,
-    iosAppDomain,
-    iosUniversalLinkDomains,
-  });
+const withBranch: ConfigPlugin<ConfigData> = (config, branchConfig = {}) => {
+  config = withBranchAndroid(config, branchConfig);
+  config = withBranchIOS(config, branchConfig);
+
   return config;
 };
 
 let pkg: { name: string; version?: string } = {
   name: "react-native-branch",
 };
+
 try {
   const branchPkg = require("react-native-branch/package.json");
   pkg = branchPkg;

--- a/packages/react-native-branch/src/withBranchAndroid.ts
+++ b/packages/react-native-branch/src/withBranchAndroid.ts
@@ -1,9 +1,10 @@
-import { ExpoConfig } from "expo/config";
 import {
   AndroidConfig,
   ConfigPlugin,
   withAndroidManifest,
 } from "expo/config-plugins";
+
+import { BranchKeys, ConfigData } from "./types";
 
 const {
   addMetaDataItemToMainApplication,
@@ -12,41 +13,78 @@ const {
 } = AndroidConfig.Manifest;
 
 const META_BRANCH_KEY = "io.branch.sdk.BranchKey";
+const META_BRANCH_KEY_TEST = "io.branch.sdk.BranchKey.test";
+const META_BRANCH_KEY_TEST_MODE = "io.branch.sdk.TestMode";
 
-export function getBranchApiKey(config: ExpoConfig) {
-  return config.android?.config?.branch?.apiKey ?? null;
-}
-
-export function setBranchApiKey(
-  apiKey: string,
-  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+export function setBranchApiKeys(
+  { apiKey, testApiKey }: BranchKeys,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
 ) {
   const mainApplication = getMainApplicationOrThrow(androidManifest);
 
   if (apiKey) {
-    // If the item exists, add it back
     addMetaDataItemToMainApplication(mainApplication, META_BRANCH_KEY, apiKey);
   } else {
-    // Remove any existing item
     removeMetaDataItemFromMainApplication(mainApplication, META_BRANCH_KEY);
+  }
+
+  if (testApiKey) {
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      META_BRANCH_KEY_TEST,
+      testApiKey
+    );
+  } else {
+    removeMetaDataItemFromMainApplication(
+      mainApplication,
+      META_BRANCH_KEY_TEST
+    );
   }
 
   return androidManifest;
 }
 
-export const withBranchAndroid: ConfigPlugin<{ apiKey?: string }> = (
-  config,
-  data,
-) => {
-  const apiKey = data.apiKey ?? getBranchApiKey(config);
+export function setBranchTestMode(
+  enableTestEnvironment: boolean,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+) {
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    META_BRANCH_KEY_TEST_MODE,
+    `${enableTestEnvironment}`
+  );
+
+  return androidManifest;
+}
+
+export const withBranchAndroid: ConfigPlugin<ConfigData> = (config, data) => {
+  const apiKey = data.apiKey ?? config.android?.config?.branch?.apiKey ?? null;
+  const testApiKey =
+    data.testApiKey ?? config.android?.config?.branch?.testApiKey ?? null;
+  const enableTestEnvironment =
+    data.enableTestEnvironment ??
+    config.android?.config?.branch?.enableTestEnvironment ??
+    null;
+
   if (!apiKey) {
     throw new Error(
-      "Branch API key is required: expo.android.config.branch.apiKey",
+      "Branch API key is required: expo.android.config.branch.apiKey"
     );
   }
 
   config = withAndroidManifest(config, (config) => {
-    config.modResults = setBranchApiKey(apiKey, config.modResults);
+    config.modResults = setBranchApiKeys(
+      { apiKey, testApiKey },
+      config.modResults
+    );
+
+    config.modResults = setBranchTestMode(
+      enableTestEnvironment,
+      config.modResults
+    );
+
     return config;
   });
 

--- a/packages/react-native-branch/src/withBranchAndroid.ts
+++ b/packages/react-native-branch/src/withBranchAndroid.ts
@@ -44,7 +44,7 @@ export function setBranchApiKeys(
   return androidManifest;
 }
 
-export function setBranchTestMode(
+export function enableBranchTestEnvironment(
   enableTestEnvironment: boolean,
   androidManifest: AndroidConfig.Manifest.AndroidManifest
 ) {
@@ -80,7 +80,7 @@ export const withBranchAndroid: ConfigPlugin<ConfigData> = (config, data) => {
       config.modResults
     );
 
-    config.modResults = setBranchTestMode(
+    config.modResults = enableBranchTestEnvironment(
       enableTestEnvironment,
       config.modResults
     );

--- a/packages/react-native-branch/src/withBranchIOS.ts
+++ b/packages/react-native-branch/src/withBranchIOS.ts
@@ -15,7 +15,7 @@ export function setBranchApiKeys(
   };
 }
 
-export function setBranchTestMode(
+export function enableBranchTestEnvironment(
   enableTestEnvironment: boolean,
   infoPlist: InfoPlist
 ) {
@@ -37,7 +37,7 @@ export const withBranchIOS: ConfigPlugin<ConfigData> = (config, data) => {
   const enableTestEnvironment =
     data.enableTestEnvironment ??
     config.android?.config?.branch?.enableTestEnvironment ??
-    null;
+    false;
 
   if (!apiKey) {
     throw new Error(
@@ -52,7 +52,7 @@ export const withBranchIOS: ConfigPlugin<ConfigData> = (config, data) => {
       config.modResults
     );
 
-    config.modResults = setBranchTestMode(
+    config.modResults = enableBranchTestEnvironment(
       enableTestEnvironment,
       config.modResults
     );

--- a/packages/react-native-branch/src/withBranchIOS.ts
+++ b/packages/react-native-branch/src/withBranchIOS.ts
@@ -1,25 +1,27 @@
-import { ExpoConfig } from "expo/config";
 import { ConfigPlugin, InfoPlist, withInfoPlist } from "expo/config-plugins";
 
-import { ConfigData } from "./types";
+import { BranchKeys, ConfigData } from "./types";
 
-export function getBranchApiKey(config: Pick<ExpoConfig, "ios">) {
-  return config.ios?.config?.branch?.apiKey ?? null;
-}
-
-export function setBranchApiKey(
-  apiKey: string | null,
-  infoPlist: InfoPlist,
+export function setBranchApiKeys(
+  { apiKey, testApiKey }: BranchKeys,
+  infoPlist: InfoPlist
 ): InfoPlist {
-  if (apiKey === null) {
-    return infoPlist;
-  }
-
   return {
     ...infoPlist,
     branch_key: {
       live: apiKey,
+      ...(testApiKey && { test: testApiKey }),
     },
+  };
+}
+
+export function setBranchTestMode(
+  enableTestEnvironment: boolean,
+  infoPlist: InfoPlist
+) {
+  return {
+    ...infoPlist,
+    branch_test_environment: enableTestEnvironment,
   };
 }
 
@@ -29,27 +31,45 @@ export const withBranchIOS: ConfigPlugin<ConfigData> = (config, data) => {
     config.ios = {};
   }
 
-  const apiKey = data.apiKey ?? getBranchApiKey(config);
+  const apiKey = data.apiKey ?? config.ios?.config?.branch?.apiKey ?? null;
+  const testApiKey =
+    data.testApiKey ?? config.ios?.config?.branch?.testApiKey ?? null;
+  const enableTestEnvironment =
+    data.enableTestEnvironment ??
+    config.android?.config?.branch?.enableTestEnvironment ??
+    null;
+
   if (!apiKey) {
     throw new Error(
-      "Branch API key is required: expo.ios.config.branch.apiKey",
+      "Branch API key is required: expo.ios.config.branch.apiKey"
     );
   }
 
   // Update the infoPlist with the branch key and branch domain
   config = withInfoPlist(config, (config) => {
-    config.modResults = setBranchApiKey(apiKey, config.modResults);
+    config.modResults = setBranchApiKeys(
+      { apiKey, testApiKey },
+      config.modResults
+    );
+
+    config.modResults = setBranchTestMode(
+      enableTestEnvironment,
+      config.modResults
+    );
+
     if (data.iosAppDomain) {
       config.modResults.branch_app_domain = data.iosAppDomain;
     } else {
       delete config.modResults.branch_app_domain;
     }
+
     if (data.iosUniversalLinkDomains) {
       config.modResults.branch_universal_link_domains =
         data.iosUniversalLinkDomains;
     } else {
       delete config.modResults.branch_universal_link_domains;
     }
+
     return config;
   });
 


### PR DESCRIPTION
# Why

Branch has a handy **test mode** that lets developers test their implementation in a sandbox, preventing data pollution in the `live` environment. At the moment this config plugin does not support the test environment feature.

[iOS docs](https://help.branch.io/developers-hub/docs/android-testing)
[Android docs](https://help.branch.io/developers-hub/docs/ios-testing#branch-test-key)

# How

I introduced this feature into the config plugin by expanding the config plugin parameters to accept some new values:
- `testApiKey` (string): the test API key to be used when the test environment is enabled
- `enableTestEnvironment` (boolean): setting this to `true` will enable the usage of the test environment.

Enabling the test environment varies between platforms:

- iOS: By injecting a `branch_test_environment` value into the generated `info.plist`, we can assert whether this value is `true` from the `applicationDidFinishLaunchWithOptions` (inside our Swift delegate) and call the appropriate SDK's mechanism to enable the test environment: `RNBranch.useTestInstance()`
- Android: The native Branch module supports enabling the test environment by adding a metadata item to the AndroidManifest: `io.branch.sdk.TestMode`. 

# Considerations / Help Needed

Part of this PR depends on some updated types in the official `expo/config-types`. Specifically, the `ExpoConfig` type supports a `branch.apiKey` field underneath the `config.ios` and `config.android`, and this config-plugin currently makes use of those values.

In an ideal world, I think the global `ExpoConfig` should have nothing that deals with Branch. It just... doesn't make sense? If this sentiment is shared between other maintainers, I'd be happy to completely kill those values from `ExpoConfig` and make the necessary changes in this PR to **only** take in options from the config-plugin itself.

Regardless, I have opened a PR in the `expo` repo to update the `ExpoConfig` type to accept the `testApiKey` and `enableTestEnvironment` parameters: https://github.com/expo/expo/pull/28084

What I'm confused about is how would these PRs be orchestrated to work together? Would we have to first merge the main repo PR and only then update the config plugin here? I'll wait for someone to chime in on this, as I'm a beginner in multi-repo contributions 😂

# Test Plan

- I updated the existing suite to include tests for the new `enableBranchTestEnvironment` functions.
- I unfortunately don't know how to test the native layer for this. I don't think this is required, however, as we currently don't have native tests for each platforms.

