### PR TITLE
feat(react-native-google-cast): add suspendSessionsWhenBackgrounded option to IOS

### DIFF
--- a/packages/react-native-google-cast/src/__tests__/__snapshots__/withIosGoogleCast-test.ts.snap
+++ b/packages/react-native-google-cast/src/__tests__/__snapshots__/withIosGoogleCast-test.ts.snap
@@ -10,12 +10,13 @@ exports[`addGoogleCastAppDelegateDidFinishLaunchingWithOptions adds maps import 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-// @generated begin react-native-google-cast-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-daa990ca400f82a13f41d1ebc1f1fe9f511f3d6d
+// @generated begin react-native-google-cast-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-7c4d7719024c020cbdbdec17652c4a5824b61c18
 #if __has_include(<GoogleCast/GoogleCast.h>)
   NSString *receiverAppID = @"foobar-bacon";
   GCKDiscoveryCriteria *criteria = [[GCKDiscoveryCriteria alloc] initWithApplicationID:receiverAppID];
   GCKCastOptions* options = [[GCKCastOptions alloc] initWithDiscoveryCriteria:criteria];
   options.startDiscoveryAfterFirstTapOnCastButton = true;
+  options.suspendSessionsWhenBackgrounded = false;
   [GCKCastContext setSharedInstanceWithOptions:options];
 #endif
 // @generated end react-native-google-cast-didFinishLaunchingWithOptions

--- a/packages/react-native-google-cast/src/__tests__/withIosGoogleCast-test.ts
+++ b/packages/react-native-google-cast/src/__tests__/withIosGoogleCast-test.ts
@@ -7,6 +7,7 @@ describe(addGoogleCastAppDelegateDidFinishLaunchingWithOptions, () => {
       getFixture("AppDelegate.mm"),
       {
         receiverAppId: "foobar-bacon",
+        suspendSessionsWhenBackgrounded: false,
       },
     );
     // matches a static snapshot

--- a/packages/react-native-google-cast/src/withGoogleCast.ts
+++ b/packages/react-native-google-cast/src/withGoogleCast.ts
@@ -19,20 +19,24 @@ const withGoogleCast: ConfigPlugin<
      * ??
      */
     androidReceiverAppId?: string;
+    /**
+     * @default true
+     */
+    iosSuspendSessionsWhenBackgrounded?: boolean;
   } | void
 > = (config, _props) => {
   const props = _props || {};
   // TODO: Are the Android and iOS receiverAppId values the same?
   config = withIosGoogleCast(config, {
     receiverAppId: props.iosReceiverAppId,
+    suspendSessionsWhenBackgrounded: props.iosSuspendSessionsWhenBackgrounded,
     // disableDiscoveryAutostart?: boolean;
     // startDiscoveryAfterFirstTapOnCastButton?: boolean;
   });
 
   config = withAndroidGoogleCast(config, {
     receiverAppId: props.androidReceiverAppId,
-    androidPlayServicesCastFrameworkVersion:
-      props.androidPlayServicesCastFrameworkVersion,
+    androidPlayServicesCastFrameworkVersion: props.androidPlayServicesCastFrameworkVersion,
   });
 
   return config;

--- a/packages/react-native-google-cast/src/withGoogleCast.ts
+++ b/packages/react-native-google-cast/src/withGoogleCast.ts
@@ -36,7 +36,8 @@ const withGoogleCast: ConfigPlugin<
 
   config = withAndroidGoogleCast(config, {
     receiverAppId: props.androidReceiverAppId,
-    androidPlayServicesCastFrameworkVersion: props.androidPlayServicesCastFrameworkVersion,
+    androidPlayServicesCastFrameworkVersion:
+      props.androidPlayServicesCastFrameworkVersion,
   });
 
   return config;

--- a/packages/react-native-google-cast/src/withIosGoogleCast.ts
+++ b/packages/react-native-google-cast/src/withIosGoogleCast.ts
@@ -102,6 +102,10 @@ export const withIosGoogleCast: ConfigPlugin<{
    * @default 'CC1AD845'
    */
   receiverAppId?: string;
+  /**
+   * @default true
+   */
+  suspendSessionsWhenBackgrounded?: boolean;
 }> = (config, props) => {
   config = withIosWifiEntitlements(config);
   config = withIosLocalNetworkPermissions(config, {
@@ -109,6 +113,7 @@ export const withIosGoogleCast: ConfigPlugin<{
   });
   config = withIosAppDelegateLoaded(config, {
     receiverAppId: props.receiverAppId,
+    suspendSessionsWhenBackgrounded: props.suspendSessionsWhenBackgrounded,
     // disableDiscoveryAutostart?: boolean;
     // startDiscoveryAfterFirstTapOnCastButton?: boolean;
   });
@@ -125,6 +130,7 @@ export const MATCH_INIT =
 
 type IosProps = {
   receiverAppId?: string | null;
+  suspendSessionsWhenBackgrounded?: boolean;
   disableDiscoveryAutostart?: boolean;
   startDiscoveryAfterFirstTapOnCastButton?: boolean;
 };
@@ -133,6 +139,7 @@ export function addGoogleCastAppDelegateDidFinishLaunchingWithOptions(
   src: string,
   {
     receiverAppId = null,
+    suspendSessionsWhenBackgrounded = true,
     disableDiscoveryAutostart = false,
     startDiscoveryAfterFirstTapOnCastButton = true,
   }: IosProps = {},
@@ -142,18 +149,13 @@ export function addGoogleCastAppDelegateDidFinishLaunchingWithOptions(
     // For extra safety
     "#if __has_include(<GoogleCast/GoogleCast.h>)",
     // TODO: This should probably read safely from a static file like the Info.plist
-    `  NSString *receiverAppID = ${
-      receiverAppId
-        ? `@"${receiverAppId}"`
-        : "kGCKDefaultMediaReceiverApplicationID"
-    };`,
+    `  NSString *receiverAppID = ${receiverAppId ? `@"${receiverAppId}"` : "kGCKDefaultMediaReceiverApplicationID"};`,
     "  GCKDiscoveryCriteria *criteria = [[GCKDiscoveryCriteria alloc] initWithApplicationID:receiverAppID];",
     "  GCKCastOptions* options = [[GCKCastOptions alloc] initWithDiscoveryCriteria:criteria];",
     // TODO: Same as above, read statically
     // `  options.disableDiscoveryAutostart = ${String(!!disableDiscoveryAutostart)};`,
-    `  options.startDiscoveryAfterFirstTapOnCastButton = ${String(
-      !!startDiscoveryAfterFirstTapOnCastButton,
-    )};`,
+    `  options.startDiscoveryAfterFirstTapOnCastButton = ${String(!!startDiscoveryAfterFirstTapOnCastButton,)};`,
+    `  options.suspendSessionsWhenBackgrounded = ${String(!!suspendSessionsWhenBackgrounded,)};`,
     "  [GCKCastContext setSharedInstanceWithOptions:options];",
     "#endif",
   );

--- a/packages/react-native-google-cast/src/withIosGoogleCast.ts
+++ b/packages/react-native-google-cast/src/withIosGoogleCast.ts
@@ -154,8 +154,8 @@ export function addGoogleCastAppDelegateDidFinishLaunchingWithOptions(
     "  GCKCastOptions* options = [[GCKCastOptions alloc] initWithDiscoveryCriteria:criteria];",
     // TODO: Same as above, read statically
     // `  options.disableDiscoveryAutostart = ${String(!!disableDiscoveryAutostart)};`,
-    `  options.startDiscoveryAfterFirstTapOnCastButton = ${String(!!startDiscoveryAfterFirstTapOnCastButton,)};`,
-    `  options.suspendSessionsWhenBackgrounded = ${String(!!suspendSessionsWhenBackgrounded,)};`,
+    `  options.startDiscoveryAfterFirstTapOnCastButton = ${String(!!startDiscoveryAfterFirstTapOnCastButton)};`,
+    `  options.suspendSessionsWhenBackgrounded = ${String(!!suspendSessionsWhenBackgrounded)};`,
     "  [GCKCastContext setSharedInstanceWithOptions:options];",
     "#endif",
   );


### PR DESCRIPTION
# Why
This option is usefull to enable background streaming using react-native-google-cast.

https://github.com/react-native-google-cast/react-native-google-cast/blob/main/src/api/useCastSession.ts
> This is primarily targeted at iOS which by default [suspends sessions when backgrounded](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_cast_options#a0edf44953049a7d888847745a387c9dc). Alternatively, you can set `options.suspendSessionsWhenBackgrounded = false` when initializing the CastContext in `AppDelegate`.

# How
Added the option to the plugin :)

# Test Plan
I do not have access to an IOS device, but I did change the jest test suite to also check if the file generated is correct. Someone should run this with the example app to verify that this option is not breaking the app.