### PR TITLE
Add note about usage in App Store listing

### DIFF
--- a/packages/react-native-dynamic-app-icon/README.md
+++ b/packages/react-native-dynamic-app-icon/README.md
@@ -61,3 +61,7 @@ In list format, icons are named after the item index (`'0', '1', '2'`), they can
 This isn't tied to `react-native-dynamic-app-icon` in any way, so any method of swapping icons works.
 
 <!-- Android support: https://github.com/myinnos/AppIconNameChanger -->
+
+## App Store usage
+
+This package is for programmatic use only. To use various app icon variations in the App Store listing (e.g., for A/B testing), consult to [this package](https://github.com/convychat/expo-app-icon-variations).


### PR DESCRIPTION
# Why

Hi! First of all, thanks for your work. I'm a huge fan of Expo.

I wanted to use `react-native-dynamic-app-icon` for creating icon A/B testing in my App Store listing, but, unfortunately, this package doesn't add icons as `.appiconset`, which is required for App Store Connect. So I've created another config plugin to make it possible. I thought it would be useful to add a reference for those who were searching like me.

Not intended as self-promotion :)
