### PR TITLE
fix(react-native-dynamic-app-icon): add exact ipad sizes `152`/`167` for exported icons

### DIFF
--- a/apps/react-native-dynamic-app-icon/app.json
+++ b/apps/react-native-dynamic-app-icon/app.json
@@ -3,6 +3,9 @@
     "name": "app-icon",
     "icon": "./assets/icons/winter.png",
     "platforms": ["ios"],
+    "ios": {
+      "supportsTablet": true
+    },
     "plugins": [
       [
         "@config-plugins/react-native-dynamic-app-icon",

--- a/packages/react-native-dynamic-app-icon/src/index.ts
+++ b/packages/react-native-dynamic-app-icon/src/index.ts
@@ -133,6 +133,43 @@ const withIconXcodeProject: ConfigPlugin<Props> = (config, { icons }) => {
           console.log("Skipping duplicate: ", iconFileName);
         }
       }
+
+      // Temporary ipad sizes to check if Apple accepts these sizes
+      // TODO(cedric): clean this up and merge into existing scale API
+      const ipadx2FileName = getIconName(key, size, 2, true);
+      if (
+        !group?.children.some(
+          ({ comment }: { comment: string }) => comment === ipadx2FileName,
+        )
+      ) {
+        // Only write the file if it doesn't already exist.
+        config.modResults = IOSConfig.XcodeUtils.addResourceFileToGroup({
+          filepath: path.join(groupPath, ipadx2FileName),
+          groupName: groupPath,
+          project: config.modResults,
+          isBuildFile: true,
+          verbose: true,
+        });
+      } else {
+        console.log("Skipping duplicate: ", ipadx2FileName);
+      }
+      const ipadx3FileName = getIconName(key, size, 3, true);
+      if (
+        !group?.children.some(
+          ({ comment }: { comment: string }) => comment === ipadx3FileName,
+        )
+      ) {
+        // Only write the file if it doesn't already exist.
+        config.modResults = IOSConfig.XcodeUtils.addResourceFileToGroup({
+          filepath: path.join(groupPath, ipadx3FileName),
+          groupName: groupPath,
+          project: config.modResults,
+          isBuildFile: true,
+          verbose: true,
+        });
+      } else {
+        console.log("Skipping duplicate: ", ipadx3FileName);
+      }
     });
 
     return config;

--- a/packages/react-native-dynamic-app-icon/src/index.ts
+++ b/packages/react-native-dynamic-app-icon/src/index.ts
@@ -1,7 +1,7 @@
+import type { ExpoConfig } from "@expo/config";
 import { generateImageAsync } from "@expo/image-utils";
 import {
-  ConfigPlugin,
-  ExportedConfigWithProps,
+  type ConfigPlugin,
   IOSConfig,
   withDangerousMod,
   withInfoPlist,
@@ -12,58 +12,60 @@ import path from "path";
 // @ts-ignore
 import pbxFile from "xcode/lib/pbxFile";
 
-const folderName = "DynamicAppIcons";
-const size = 60;
-const scales = [2, 3];
+/** The default icon folder name to export to */
+const ICON_FOLDER_NAME = "DynamicAppIcons";
 
-type IconSet = Record<string, { image: string; prerendered?: boolean }>;
+/**
+ * The default icon dimensions to export.
+ *
+ * @see https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS-app-icon-sizes
+ */
+const ICON_DIMENSIONS: IconDimensions[] = [
+  // iPhone, iPad, MacOS, ...
+  { scale: 2, size: 60 * 2 },
+  { scale: 3, size: 60 * 3 },
+  // iPad only
+  { scale: 2, size: 152, target: "ipad" },
+  { scale: 3, size: 167, target: "ipad" },
+];
+
+type IconDimensions = {
+  /** The scale of the icon itself, only affects exported file name */
+  scale: number;
+  /** Both width and height of the icon */
+  size: number;
+  /** Special target of the icon dimension, if any */
+  target?: "ipad";
+};
+
+type IconSet = Record<string, IconSetProps>;
+type IconSetProps = { image: string; prerendered?: boolean };
 
 type Props = {
   icons: Record<string, { image: string; prerendered?: boolean }>;
+  dimensions: IconDimensions[];
 };
-
-function arrayToImages(images: string[]) {
-  return images.reduce(
-    (prev, curr, i) => ({ ...prev, [i]: { image: curr } }),
-    {},
-  );
-}
 
 const withDynamicIcon: ConfigPlugin<string[] | IconSet | void> = (
   config,
   props = {},
 ) => {
-  const _props = props || {};
+  const icons = resolveIcons(props);
+  const dimensions = resolveIconDimensions(config);
 
-  let prepped: Props["icons"] = {};
+  config = withIconXcodeProject(config, { icons, dimensions });
+  config = withIconInfoPlist(config, { icons, dimensions });
+  config = withIconImages(config, { icons, dimensions });
 
-  if (Array.isArray(_props)) {
-    prepped = arrayToImages(_props);
-  } else if (_props) {
-    prepped = _props;
-  }
-
-  config = withIconXcodeProject(config, { icons: prepped });
-  config = withIconInfoPlist(config, { icons: prepped });
-  config = withIconImages(config, { icons: prepped });
   return config;
 };
 
-function getIconName(name: string, size: number, scale?: number, ipad = false) {
-  const fileName = `${name}-Icon-${size}x${size}`;
-
-  if (scale != null) {
-    // TODO(cedric): clean this up and merge into existing scale API
-    return ipad
-      ? `${fileName}@${scale}x~ipad.png`
-      : `${fileName}@${scale}x.png`;
-  }
-  return fileName;
-}
-
-const withIconXcodeProject: ConfigPlugin<Props> = (config, { icons }) => {
+const withIconXcodeProject: ConfigPlugin<Props> = (
+  config,
+  { icons, dimensions },
+) => {
   return withXcodeProject(config, async (config) => {
-    const groupPath = `${config.modRequest.projectName!}/${folderName}`;
+    const groupPath = `${config.modRequest.projectName!}/${ICON_FOLDER_NAME}`;
     const group = IOSConfig.XcodeUtils.ensureGroupRecursively(
       config.modResults,
       groupPath,
@@ -112,9 +114,10 @@ const withIconXcodeProject: ConfigPlugin<Props> = (config, { icons }) => {
 
     // Link new assets
 
-    await iterateIconsAsync({ icons }, async (key, icon, index) => {
-      for (const scale of scales) {
-        const iconFileName = getIconName(key, size, scale);
+    await iterateIconsAndDimensionsAsync(
+      { icons, dimensions },
+      async (key, { dimension }) => {
+        const iconFileName = getIconFileName(key, dimension);
 
         if (
           !group?.children.some(
@@ -132,67 +135,36 @@ const withIconXcodeProject: ConfigPlugin<Props> = (config, { icons }) => {
         } else {
           console.log("Skipping duplicate: ", iconFileName);
         }
-      }
-
-      // Temporary ipad sizes to check if Apple accepts these sizes
-      // TODO(cedric): clean this up and merge into existing scale API
-      const ipadx2FileName = getIconName(key, size, 2, true);
-      if (
-        !group?.children.some(
-          ({ comment }: { comment: string }) => comment === ipadx2FileName,
-        )
-      ) {
-        // Only write the file if it doesn't already exist.
-        config.modResults = IOSConfig.XcodeUtils.addResourceFileToGroup({
-          filepath: path.join(groupPath, ipadx2FileName),
-          groupName: groupPath,
-          project: config.modResults,
-          isBuildFile: true,
-          verbose: true,
-        });
-      } else {
-        console.log("Skipping duplicate: ", ipadx2FileName);
-      }
-      const ipadx3FileName = getIconName(key, size, 3, true);
-      if (
-        !group?.children.some(
-          ({ comment }: { comment: string }) => comment === ipadx3FileName,
-        )
-      ) {
-        // Only write the file if it doesn't already exist.
-        config.modResults = IOSConfig.XcodeUtils.addResourceFileToGroup({
-          filepath: path.join(groupPath, ipadx3FileName),
-          groupName: groupPath,
-          project: config.modResults,
-          isBuildFile: true,
-          verbose: true,
-        });
-      } else {
-        console.log("Skipping duplicate: ", ipadx3FileName);
-      }
-    });
+      },
+    );
 
     return config;
   });
 };
 
-const withIconInfoPlist: ConfigPlugin<Props> = (config, { icons }) => {
+const withIconInfoPlist: ConfigPlugin<Props> = (
+  config,
+  { icons, dimensions },
+) => {
   return withInfoPlist(config, async (config) => {
     const altIcons: Record<
       string,
       { CFBundleIconFiles: string[]; UIPrerenderedIcon: boolean }
     > = {};
 
-    await iterateIconsAsync({ icons }, async (key, icon) => {
-      altIcons[key] = {
-        CFBundleIconFiles: [
-          // Must be a file path relative to the source root (not a icon set it seems).
-          // i.e. `Bacon-Icon-60x60` when the image is `ios/somn/appIcons/Bacon-Icon-60x60@2x.png`
-          getIconName(key, size),
-        ],
-        UIPrerenderedIcon: !!icon.prerendered,
-      };
-    });
+    await iterateIconsAndDimensionsAsync(
+      { icons, dimensions },
+      async (key, { icon, dimension }) => {
+        altIcons[key] = {
+          CFBundleIconFiles: [
+            // Must be a file path relative to the source root (not a icon set it seems).
+            // i.e. `Bacon-Icon-60x60` when the image is `ios/somn/appIcons/Bacon-Icon-60x60@2x.png`
+            getIconFileName(key, dimension),
+          ],
+          UIPrerenderedIcon: !!icon.prerendered,
+        };
+      },
+    );
 
     function applyToPlist(key: string) {
       if (
@@ -220,122 +192,110 @@ const withIconInfoPlist: ConfigPlugin<Props> = (config, { icons }) => {
   });
 };
 
-const withIconImages: ConfigPlugin<Props> = (config, props) => {
+const withIconImages: ConfigPlugin<Props> = (config, { icons, dimensions }) => {
   return withDangerousMod(config, [
     "ios",
     async (config) => {
-      await createIconsAsync(config, props);
+      const iosRoot = path.join(
+        config.modRequest.platformProjectRoot,
+        config.modRequest.projectName!,
+      );
+
+      // Delete all existing assets
+      await fs.promises
+        .rm(path.join(iosRoot, ICON_FOLDER_NAME), {
+          recursive: true,
+          force: true,
+        })
+        .catch(() => null);
+
+      // Ensure directory exists
+      await fs.promises.mkdir(path.join(iosRoot, ICON_FOLDER_NAME), {
+        recursive: true,
+      });
+
+      // Generate new assets
+      await iterateIconsAndDimensionsAsync(
+        { icons, dimensions },
+        async (key, { icon, dimension }) => {
+          const iconFileName = getIconFileName(key, dimension);
+          const fileName = path.join(ICON_FOLDER_NAME, iconFileName);
+          const outputPath = path.join(iosRoot, fileName);
+
+          const { source } = await generateImageAsync(
+            {
+              projectRoot: config.modRequest.projectRoot,
+              cacheType: "react-native-dynamic-app-icon",
+            },
+            {
+              name: iconFileName,
+              src: icon.image,
+              removeTransparency: true,
+              backgroundColor: "#ffffff",
+              resizeMode: "cover",
+              width: dimension.size,
+              height: dimension.size,
+            },
+          );
+
+          await fs.promises.writeFile(outputPath, source);
+        },
+      );
+
       return config;
     },
   ]);
 };
 
-async function createIconsAsync(
-  config: ExportedConfigWithProps,
-  { icons }: Props,
-) {
-  const iosRoot = path.join(
-    config.modRequest.platformProjectRoot,
-    config.modRequest.projectName!,
-  );
+/** Resolve and sanitize the icon set from config plugin props. */
+function resolveIcons(props: string[] | IconSet | void): Props["icons"] {
+  let icons: Props["icons"] = {};
 
-  // Delete all existing assets
-  await fs.promises
-    .rm(path.join(iosRoot, folderName), { recursive: true, force: true })
-    .catch(() => null);
-  // Ensure directory exists
-  await fs.promises.mkdir(path.join(iosRoot, folderName), { recursive: true });
-  // Generate new assets
-  await iterateIconsAsync({ icons }, async (key, icon) => {
-    for (const scale of scales) {
-      const iconFileName = getIconName(key, size, scale);
-      const fileName = path.join(folderName, iconFileName);
-      const outputPath = path.join(iosRoot, fileName);
-
-      const scaledSize = scale * size;
-      const { source } = await generateImageAsync(
-        {
-          projectRoot: config.modRequest.projectRoot,
-          cacheType: "react-native-dynamic-app-icon",
-        },
-        {
-          name: iconFileName,
-          src: icon.image,
-          removeTransparency: true,
-          backgroundColor: "#ffffff",
-          resizeMode: "cover",
-          width: scaledSize,
-          height: scaledSize,
-        },
-      );
-
-      await fs.promises.writeFile(outputPath, source);
-    }
-
-    // Temporary ipad sizes to check if Apple accepts these sizes
-    // TODO(cedric): clean this up and merge into existing scale API
-    const { source: ipadx2 } = await generateImageAsync(
-      {
-        projectRoot: config.modRequest.projectRoot,
-        cacheType: "react-native-dynamic-app-icon",
-      },
-      {
-        name: getIconName(key, size, 2, true),
-        src: icon.image,
-        removeTransparency: true,
-        backgroundColor: "#ffffff",
-        resizeMode: "cover",
-        width: 152, // See: https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS-app-icon-sizes
-        height: 152, // See: https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS-app-icon-sizes
-      },
+  if (Array.isArray(props)) {
+    icons = props.reduce(
+      (prev, curr, i) => ({ ...prev, [i]: { image: curr } }),
+      {},
     );
-    const { source: ipadx3 } = await generateImageAsync(
-      {
-        projectRoot: config.modRequest.projectRoot,
-        cacheType: "react-native-dynamic-app-icon",
-      },
-      {
-        name: getIconName(key, size, 3, true),
-        src: icon.image,
-        removeTransparency: true,
-        backgroundColor: "#ffffff",
-        resizeMode: "cover",
-        width: 167, // See: https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS-app-icon-sizes
-        height: 167, // See: https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS-app-icon-sizes
-      },
-    );
-    await Promise.all([
-      fs.promises.writeFile(
-        path.join(
-          iosRoot,
-          path.join(folderName, getIconName(key, size, 2, true)),
-        ),
-        ipadx2,
-      ),
-      fs.promises.writeFile(
-        path.join(
-          iosRoot,
-          path.join(folderName, getIconName(key, size, 3, true)),
-        ),
-        ipadx3,
-      ),
-    ]);
-  });
+  } else if (props) {
+    icons = props;
+  }
+
+  return icons;
 }
 
-async function iterateIconsAsync(
-  { icons }: Props,
+/** Resolve the required icon dimension/target based on the app config. */
+function resolveIconDimensions(config: ExpoConfig) {
+  const targets: NonNullable<IconDimensions["target"]>[] = [];
+
+  if (config.ios?.supportsTablet) {
+    targets.push("ipad");
+  }
+
+  return ICON_DIMENSIONS.filter(
+    (dimension) => !dimension.target || targets.includes(dimension.target),
+  );
+}
+
+/** Get the icon file name based on name and dimensions  */
+function getIconFileName(name: string, dimension: IconDimensions) {
+  const { size, scale } = dimension;
+  const target = dimension.target ? `~${dimension.target}` : "";
+
+  return `${name}-Icon-${size}x${size}@${scale}x${target}.png`;
+}
+
+/** Iterate all combinations of icons and dimensions to export */
+async function iterateIconsAndDimensionsAsync(
+  { icons, dimensions }: Props,
   callback: (
-    key: string,
-    icon: { image: string; prerendered?: boolean },
-    index: number,
+    iconKey: string,
+    iconAndDimension: { icon: IconSetProps; dimension: IconDimensions },
   ) => Promise<void>,
 ) {
-  const entries = Object.entries(icons);
-  for (let i = 0; i < entries.length; i++) {
-    const [key, val] = entries[i];
-
-    await callback(key, val, i);
+  for (const [iconKey, icon] of Object.entries(icons)) {
+    for (const dimension of dimensions) {
+      await callback(iconKey, { icon, dimension });
+    }
   }
 }
 


### PR DESCRIPTION
# Why

This is an attempt to satisfy Apple's request for dynamic app icons on iPad, using sizes `152x152` and `167x167`.

- See: https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS-app-icon-sizes
- See: https://stackoverflow.com/a/70986182

# How

- Replaced fixed `size` and `scales` with `IconDimension`
- Added iPad specific icon dimensions, turning on/off based on `ios.supportsTablets`

# Test Plan

- Run example app `apps/react-native-dynamic-app-icon`
  - iPad support is now enabled
- Verify that iPad icons are exported + registered, and plist contains right icon info 