### PR TITLE
feat: adds expo-react-native-freshchat to out-of-tree plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ More out-of-tree plugins which can be used to configure more packages.
 - [@ouvio/react-native-background-location-plugin](https://www.npmjs.com/package/@ouvio/react-native-background-location-plugin) (for use with `react-native-background-location-plugin`)
 - [expo-community-flipper](https://www.npmjs.com/package/expo-community-flipper) (for use with Flipper)
 - [expo-appcenter](https://www.npmjs.com/package/expo-appcenter) (for use with `appcenter`)
+- [expo-react-native-freshchat](https://www.npmjs.com/package/expo-react-native-freshchat) (for use with `react-native-freshchat-sdk`)
 - [react-native-keyevent-expo-config-plugin](https://github.com/chronsyn/react-native-keyevent-expo-config-plugin) (for use with `react-native-keyevent`)
 - [watermelondb-expo-plugin](https://github.com/morrowdigital/watermelondb-expo-plugin) (for use with `@nozbe/watermelondb`)
 


### PR DESCRIPTION
# Why

Freshchat's RN implementation requires some native changes. I wanted to build a plugin to help users quickly apply these changes consistently when using CNG.

# How

This plugin follows the steps outlined in [Freshchat SDK documentation](https://developers.freshchat.com/mobile/#getting-started)

# Test Plan

No tests required, this is a doc change only
