### PR TITLE
fix(branch): Fix branch plugin namespace

### DIFF
--- a/packages/react-native-branch/android/build.gradle
+++ b/packages/react-native-branch/android/build.gradle
@@ -11,7 +11,7 @@ useDefaultAndroidSdkVersions()
 useExpoPublishing()
 
 android {
-  namespace "expo.modules.haptics"
+  namespace "expo.modules.adapters.branch"
   defaultConfig {
     versionCode 5
     versionName '5.0.0'

--- a/packages/react-native-branch/package.json
+++ b/packages/react-native-branch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@config-plugins/react-native-branch",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Config plugin to auto configure react-native-branch on prebuild",
   "author": "650 Industries, Inc.",
   "license": "MIT",


### PR DESCRIPTION


# Why

Branch integration is broken with SDK 52: https://github.com/expo/config-plugins/issues/259

The namespace is incorrect.



