### PR TITLE
fix: update namespace for react-native-branch config plugin

### DIFF
--- a/packages/react-native-branch/android/build.gradle
+++ b/packages/react-native-branch/android/build.gradle
@@ -11,7 +11,7 @@ useDefaultAndroidSdkVersions()
 useExpoPublishing()
 
 android {
-  namespace "expo.modules.haptics"
+  namespace "expo.configplugins.branch"
   defaultConfig {
     versionCode 5
     versionName '5.0.0'


### PR DESCRIPTION
Replace conflicting namespace which would cause android build to fail if using expo-haptics.
