### PR TITLE
chore(react-native-branch): update `README.md` with instructions for `iosUniversalLinkDomains` configuration

### DIFF
--- a/packages/react-native-branch/README.md
+++ b/packages/react-native-branch/README.md
@@ -40,6 +40,7 @@ The plugin provides props for extra customization. Every time you change the pro
 
 - `apiKey` (_string_): Branch API key. Optional.
 - `iosAppDomain` (_string_): App Domain for iOS. Optional.
+- `iosUniversalLinkDomains` (_string[]_): Universal link domains for iOS. Optional.
 
 #### Example
 
@@ -50,7 +51,8 @@ The plugin provides props for extra customization. Every time you change the pro
       "@config-plugins/react-native-branch",
       {
         "apiKey": "key_live_f9f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8",
-        "iosAppDomain": "awesome-alternate.app.link"
+        "iosAppDomain": "awesome-alternate.app.link",
+        "iosUniversalLinkDomains": ["awesome.app.link", "awesome-alternate.app.link", "awesome.test.app.link"]
       }
     ]
   ]


### PR DESCRIPTION
Add documentation for the `iosUniversalLinkDomains` field. 

This field is defined [here](https://github.com/expo/config-plugins/blob/b368b0bfcb808fa724f14bd3ee7715d1cabb6fff/packages/react-native-branch/src/types.ts#L4) and used [here](https://github.com/expo/config-plugins/blob/b368b0bfcb808fa724f14bd3ee7715d1cabb6fff/packages/react-native-branch/src/withBranchIOS.ts#L51-L54).