### PR TITLE
feat(adjust): add meta install referrer

### DIFF
--- a/packages/react-native-adjust/README.md
+++ b/packages/react-native-adjust/README.md
@@ -32,6 +32,10 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 }
 ```
 
+## Configuration Options
+
+### Android 12+ Support
+
 If you are targeting Android 12 and above (API level 31), you need to add it in the options of the plugin:
 
 ```json
@@ -43,5 +47,39 @@ If you are targeting Android 12 and above (API level 31), you need to add it in 
 ```
 
 This will add the [appropriate permission](https://github.com/adjust/react_native_sdk#add-permission-to-gather-google-advertising-id) for you.
+
+### Meta Install Referrer
+
+If you need to track Meta (Facebook) install referrers, you can enable the Meta install referrer dependency:
+
+```json
+{
+  "plugins": [
+    ["@config-plugins/react-native-adjust", { "metaInstallReferrer": true }]
+  ]
+}
+```
+
+This will add the `com.adjust.sdk:adjust-android-meta-referrer:5.4.0` dependency to your Android build.
+
+Doc: https://dev.adjust.com/en/sdk/react-native/plugins/meta-referrer-plugin
+
+### Combined Configuration
+
+You can combine multiple options:
+
+```json
+{
+  "plugins": [
+    [
+      "@config-plugins/react-native-adjust", 
+      { 
+        "targetAndroid12": true,
+        "metaInstallReferrer": true
+      }
+    ]
+  ]
+}
+```
 
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

This PR adds support for the Meta (Facebook) install referrer plugin in the react-native-adjust config plugin. The Meta install referrer is required for tracking Facebook ad campaigns and attribution in React Native apps using the Adjust SDK.

Currently, users need to manually add the `com.adjust.sdk:adjust-android-meta-referrer:5.4.0` dependency to their Android build.gradle file when they want to track Meta install referrers. This enhancement allows the config plugin to automatically handle this dependency injection when configured.

Reference: https://dev.adjust.com/en/sdk/react-native/plugins/meta-referrer-plugin

# How

- Added a new optional `metaInstallReferrer` boolean parameter to the plugin configuration options
- Modified the `addAndroidPackagingOptions` function to conditionally include the Meta install referrer dependency (`com.adjust.sdk:adjust-android-meta-referrer:5.4.0`) when the parameter is enabled
- Updated TypeScript type definitions to include the new parameter alongside the existing `targetAndroid12` option
- Enhanced the `withGradle` function to pass through the new parameter to the dependency injection logic
- Updated README.md with comprehensive documentation including usage examples and a link to the official Adjust documentation
- Maintained backward compatibility - existing configurations continue to work without changes

The implementation follows the existing code patterns and architecture, ensuring consistency with the current plugin structure.

# Test Plan

**Manual Testing:**

1. **Basic functionality test:**
   ```json
   {
     "plugins": [
       ["@config-plugins/react-native-adjust", { "metaInstallReferrer": true }]
     ]
   }
   ```
   - Run `npx expo prebuild --clean`
   - Verify that `android/app/build.gradle` contains the Meta install referrer dependency

2. **Combined configuration test:**
   ```json
   {
     "plugins": [
       [
         "@config-plugins/react-native-adjust", 
         { 
           "targetAndroid12": true,
           "metaInstallReferrer": true
         }
       ]
     ]
   }
   ```
   - Run `npx expo prebuild --clean`
   - Verify both the Android 12 permission and Meta dependency are added

3. **Backward compatibility test:**
   ```json
   {
     "plugins": ["@config-plugins/react-native-adjust"]
   }
   ```
   - Run `npx expo prebuild --clean`
   - Verify existing functionality works without the Meta dependency

4. **Parameter disabled test:**
   ```json
   {
     "plugins": [
       ["@config-plugins/react-native-adjust", { "metaInstallReferrer": false }]
     ]
   }
   ```
   - Run `npx expo prebuild --clean`
   - Verify Meta dependency is not added when explicitly disabled

**Expected Results:**
- When `metaInstallReferrer: true`, the generated `android/app/build.gradle` should contain:
  ```gradle
  implementation 'com.adjust.sdk:adjust-android-meta-referrer:5.4.0'
  ```
- When the parameter is not set or `false`, the Meta dependency should not be present
- All existing functionality should remain unchanged
- TypeScript compilation should pass without errors