### PR TITLE
feat(adjust): remove iAd.framework as it's legacy

### DIFF
--- a/packages/react-native-adjust/src/withReactNativeAdjust.ts
+++ b/packages/react-native-adjust/src/withReactNativeAdjust.ts
@@ -69,11 +69,6 @@ const withAdjustPlugin: ConfigPlugin<void | { targetAndroid12?: boolean }> = (
   const props = _props || {};
 
   config = withXcodeLinkBinaryWithLibraries(config, {
-    library: "iAd.framework",
-    status: "optional",
-  });
-
-  config = withXcodeLinkBinaryWithLibraries(config, {
     library: "AdServices.framework",
     status: "optional",
   });


### PR DESCRIPTION
<!--
🚨 We use semantic release (a bot publishes everything automatically)
🚨 so please use conventional commit style for the PR title:
🚨 https://www.conventionalcommits.org/en/v1.0.0/
🚨 Example: feat(detox): add new step
-->

# Why

Remove the legacy `iAd.framework` from the react-native-adjust config plugin. According to [Apple's documentation](https://developer.apple.com/documentation/iad), iAd has been deprecated and is no longer supported. The framework should not be included in modern iOS apps.

# How

- Removed the `iAd.framework` linking from the `withAdjustPlugin` function
- Kept all other iOS frameworks (AdServices, AdSupport, StoreKit, AppTrackingTransparency) which are still actively supported
- No changes to Android configuration or plugin parameters

# Test Plan

**Manual Testing:**

1. **Basic functionality test:**
   ```json
   {
     "plugins": ["@config-plugins/react-native-adjust"]
   }
   ```
   - Run `npx expo prebuild --clean`
   - Verify that `iAd.framework` is not linked in the iOS project
   - Verify other frameworks (AdServices, AdSupport, StoreKit, AppTrackingTransparency) are still properly linked

2. **Build verification:**
   - Run `npx expo run:ios`
   - Verify the app builds successfully without iAd.framework
   - Confirm Adjust SDK functionality remains intact

**Expected Results:**
- iOS project should not include `iAd.framework` in linked libraries
- All other iOS frameworks should remain properly configured
- App should build and run without issues
- Adjust SDK attribution and tracking should continue to work normally