### PR TITLE
test: update Node versions in test workflow to use maintenance and active LTS releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["18"]
+        node: ["20", "22"]
     name: Build with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["18"]
+        node: ["20", "22"]
         package: [
             # Manually add packages here
             ios-stickers,


### PR DESCRIPTION
# Why

The existing CI workflow uses Node v18, which [is marked as EOL here](https://nodejs.org/en/about/previous-releases)

# How

Replaced v18 in the build matrix with v20 and v22.

# Test Plan

CI