### PR TITLE
chore: restore `index.js` in `apps/app`

### DIFF
--- a/apps/app/index.js
+++ b/apps/app/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from "expo";
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);


### PR DESCRIPTION
# Why

It seems like `apps/app/index.js` was mistakenly deleted in 00197c766b131ef4ca58d12eefbf2f67a7d2197a

# How

Restored the file and removed Detox-related setup.

# Test Plan

```
cd apps/app
yarn ios
```