### PR TITLE
chore: sync GitHub issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,6 +14,10 @@ contact_links:
       stream read/write for process large files.
     name: 📦 react-native-blob-util issues
     url: https://github.com/RonRadtke/react-native-blob-util/issues
+  - about: Branch Metrics React Native SDK
+    name: 📦 react-native-branch issues
+    url: >-
+      https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/issues
   - about: iOS 10 CallKit and Android ConnectionService Framework For React Native
     name: 📦 react-native-callkeep issues
     url: https://github.com/react-native-webrtc/react-native-callkeep/issues


### PR DESCRIPTION
# Why

The GitHub issue template was out-of-sync and didn't include `react-native-branch`

# How

Ran `yarn update-issue-template`

# Test Plan

None required