### PR TITLE
fix(react-native-branch): defer api key validation to mods

### DIFF
--- a/packages/react-native-branch/src/__tests__/withBranchAndroid.test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchAndroid.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 import {
   setBranchApiKeys,
   enableBranchTestEnvironment,
+  withBranchAndroid,
 } from "../withBranchAndroid";
 
 const { findMetaDataItem, getMainApplication, readAndroidManifestAsync } =
@@ -62,5 +63,19 @@ describe(enableBranchTestEnvironment, () => {
     expect(
       findMetaDataItem(mainApplication, "io.branch.sdk.TestMode"),
     ).toBeGreaterThan(-1);
+  });
+});
+
+describe(withBranchAndroid, () => {
+  it("does not require the api key while evaluating the config plugin", () => {
+    expect(() =>
+      withBranchAndroid(
+        {
+          name: "example",
+          slug: "example",
+        },
+        {},
+      ),
+    ).not.toThrow();
   });
 });

--- a/packages/react-native-branch/src/__tests__/withBranchIOS.test.ts
+++ b/packages/react-native-branch/src/__tests__/withBranchIOS.test.ts
@@ -1,6 +1,7 @@
 import {
   setBranchApiKeys,
   enableBranchTestEnvironment,
+  withBranchIOS,
 } from "../withBranchIOS";
 
 describe(setBranchApiKeys, () => {
@@ -32,5 +33,19 @@ describe(enableBranchTestEnvironment, () => {
     expect(enableBranchTestEnvironment(true, {})).toMatchObject({
       branch_test_environment: true,
     });
+  });
+});
+
+describe(withBranchIOS, () => {
+  it("does not require the api key while evaluating the config plugin", () => {
+    expect(() =>
+      withBranchIOS(
+        {
+          name: "example",
+          slug: "example",
+        },
+        {},
+      ),
+    ).not.toThrow();
   });
 });

--- a/packages/react-native-branch/src/withBranchAndroid.ts
+++ b/packages/react-native-branch/src/withBranchAndroid.ts
@@ -59,6 +59,14 @@ export function enableBranchTestEnvironment(
   return androidManifest;
 }
 
+function requireBranchApiKey(apiKey?: string): string {
+  if (!apiKey) {
+    throw new Error("Branch API key is required: apiKey must be provided");
+  }
+
+  return apiKey;
+}
+
 export const withBranchAndroid: ConfigPlugin<ConfigData> = (config, data) => {
   // Fall back to the Expo Config `branch.apiKey` if not provided in plugin
   // config. The `branch` property in the Expo Config is deprecated and will be
@@ -70,14 +78,13 @@ export const withBranchAndroid: ConfigPlugin<ConfigData> = (config, data) => {
         "Pass `apiKey` directly in the plugin config instead.",
     );
   }
-  const apiKey = data.apiKey ?? config.android?.config?.branch?.apiKey;
   const { testApiKey, enableTestEnvironment = false } = data;
 
-  if (!apiKey) {
-    throw new Error("Branch API key is required: apiKey must be provided");
-  }
-
   config = withAndroidManifest(config, (config) => {
+    const apiKey = requireBranchApiKey(
+      data.apiKey ?? config.android?.config?.branch?.apiKey,
+    );
+
     config.modResults = setBranchApiKeys(
       { apiKey, testApiKey },
       config.modResults,

--- a/packages/react-native-branch/src/withBranchIOS.ts
+++ b/packages/react-native-branch/src/withBranchIOS.ts
@@ -48,6 +48,14 @@ export function enableBranchTestEnvironment(
   };
 }
 
+function requireBranchApiKey(apiKey?: string): string {
+  if (!apiKey) {
+    throw new Error("Branch API key is required: apiKey must be provided");
+  }
+
+  return apiKey;
+}
+
 export const withBranchIOS: ConfigPlugin<ConfigData> = (config, data) => {
   // Ensure object exist
   if (!config.ios) {
@@ -64,12 +72,7 @@ export const withBranchIOS: ConfigPlugin<ConfigData> = (config, data) => {
         "Pass `apiKey` directly in the plugin config instead.",
     );
   }
-  const apiKey = data.apiKey ?? config.ios?.config?.branch?.apiKey;
   const { testApiKey, enableTestEnvironment = false } = data;
-
-  if (!apiKey) {
-    throw new Error("Branch API key is required: apiKey must be provided");
-  }
 
   // Add `React/RCTBridge` to bridging header
   withDangerousMod(config, [
@@ -103,6 +106,10 @@ export const withBranchIOS: ConfigPlugin<ConfigData> = (config, data) => {
 
   // Update the infoPlist with the branch key and branch domain
   config = withInfoPlist(config, (config) => {
+    const apiKey = requireBranchApiKey(
+      data.apiKey ?? config.ios?.config?.branch?.apiKey,
+    );
+
     config.modResults = setBranchApiKeys(
       { apiKey, testApiKey },
       config.modResults,


### PR DESCRIPTION
### Summary

Fixes #298.

The Branch config plugin was validating `apiKey` while the plugin function was being evaluated. That makes `eas config`/`eas build` fail when the key is sourced from EAS environment variables, because EAS evaluates the config before those env values are available.

This keeps the required key check, but moves it into the Android manifest and iOS Info.plist mods so validation happens when the native mods are applied. That lets config evaluation complete while still failing clearly if a native prebuild runs without a Branch key.

### Test Plan

- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm --filter @config-plugins/react-native-branch test`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm --filter @config-plugins/react-native-branch build`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm --filter @config-plugins/react-native-branch lint`

Note: the default local Node invocation hit the repo ESM/Babel config error. The commands above passed with local Node v22.22.0.